### PR TITLE
[codex] Add minimal WebRTC video pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PI_LIDAR_ENABLED ?= 1
 PI_LIDAR_PORT ?= /dev/ttyUSB0
 PI_VENV_DIR ?= .venv
 
-.PHONY: help serve check run backend-install backend-ensure backend-dev backend-start pc-setup pc-backend pc-web pc-start mac-setup mac-backend mac-web mac-start pi-install pi-setup pi-run pi-run-echo pi-run-esc pi-connect-echo pi-connect-esc pi-backend-check pi-keys
+.PHONY: help serve check run backend-install backend-ensure backend-dev backend-start pc-setup pc-backend pc-web pc-start mac-setup mac-backend mac-web mac-start pi-install pi-setup pi-run pi-run-echo pi-run-esc pi-run-webrtc pi-connect-echo pi-connect-esc pi-connect-webrtc-echo pi-connect-webrtc-esc pi-backend-check pi-keys
 
 help:
 	@echo "Available targets:"
@@ -32,8 +32,11 @@ help:
 	@echo "  make pi-run          - Run Raspberry Pi gateway"
 	@echo "  make pi-run-echo     - Run Pi gateway in no-hardware echo mode"
 	@echo "  make pi-run-esc      - Run Pi gateway with direct Pi GPIO ESC control"
+	@echo "  make pi-run-webrtc   - Run the Pi WebRTC camera publisher"
 	@echo "  make pi-connect-echo PC_IP=<ip> - Connect Pi echo mode to the PC backend with LiDAR streaming"
 	@echo "  make pi-connect-esc  PC_IP=<ip> - Connect Pi ESC mode to the PC backend with LiDAR streaming"
+	@echo "  make pi-connect-webrtc-echo PC_IP=<ip> - Connect Pi controls in echo mode and publish one WebRTC camera"
+	@echo "  make pi-connect-webrtc-esc  PC_IP=<ip> - Connect Pi controls in ESC mode and publish one WebRTC camera"
 	@echo "  make pi-backend-check PC_IP=<ip> - Check backend health from the Pi"
 	@echo "  make pi-keys         - Run keyboard-to-ESP serial bridge"
 	@echo "  make help   - Show this help message"
@@ -101,6 +104,9 @@ pi-run-echo:
 pi-run-esc:
 	PI_MOTOR_DRIVER=esc python3 pi/gateway.py
 
+pi-run-webrtc:
+	python3 pi/webrtc_publisher.py
+
 pi-connect-echo:
 	@if [ -z "$(HOST_IP)" ]; then \
 		echo "Usage: make pi-connect-echo PC_IP=192.168.1.25"; \
@@ -124,6 +130,36 @@ pi-connect-esc:
 	fi
 	@. "$(PI_VENV_DIR)/bin/activate"; \
 	BACKEND_WS_BASE=ws://$(HOST_IP):$(BACKEND_PORT) PI_DEVICE_ID=$(PI_DEVICE_ID) LIDAR_ENABLED=$(PI_LIDAR_ENABLED) LIDAR_SERIAL_PORT=$(PI_LIDAR_PORT) PI_MOTOR_DRIVER=esc python3 pi/gateway.py
+
+pi-connect-webrtc-echo:
+	@if [ -z "$(HOST_IP)" ]; then \
+		echo "Usage: make pi-connect-webrtc-echo PC_IP=192.168.1.25"; \
+		exit 1; \
+	fi
+	@if [ ! -f "$(PI_VENV_DIR)/bin/activate" ]; then \
+		echo "Missing $(PI_VENV_DIR)/bin/activate. Run: python3 -m venv $(PI_VENV_DIR) && make pi-setup"; \
+		exit 1; \
+	fi
+	@. "$(PI_VENV_DIR)/bin/activate"; \
+	trap 'kill 0 >/dev/null 2>&1' INT TERM EXIT; \
+	BACKEND_WS_BASE=ws://$(HOST_IP):$(BACKEND_PORT) PI_DEVICE_ID=$(PI_DEVICE_ID) LIDAR_ENABLED=$(PI_LIDAR_ENABLED) LIDAR_SERIAL_PORT=$(PI_LIDAR_PORT) PI_MOTOR_DRIVER=echo PI_CAMERA_JPEG_ENABLED=0 python3 pi/gateway.py & \
+	BACKEND_WS_BASE=ws://$(HOST_IP):$(BACKEND_PORT) PI_DEVICE_ID=$(PI_DEVICE_ID) python3 pi/webrtc_publisher.py & \
+	wait
+
+pi-connect-webrtc-esc:
+	@if [ -z "$(HOST_IP)" ]; then \
+		echo "Usage: make pi-connect-webrtc-esc PC_IP=192.168.1.25"; \
+		exit 1; \
+	fi
+	@if [ ! -f "$(PI_VENV_DIR)/bin/activate" ]; then \
+		echo "Missing $(PI_VENV_DIR)/bin/activate. Run: python3 -m venv $(PI_VENV_DIR) && make pi-setup"; \
+		exit 1; \
+	fi
+	@. "$(PI_VENV_DIR)/bin/activate"; \
+	trap 'kill 0 >/dev/null 2>&1' INT TERM EXIT; \
+	BACKEND_WS_BASE=ws://$(HOST_IP):$(BACKEND_PORT) PI_DEVICE_ID=$(PI_DEVICE_ID) LIDAR_ENABLED=$(PI_LIDAR_ENABLED) LIDAR_SERIAL_PORT=$(PI_LIDAR_PORT) PI_MOTOR_DRIVER=esc PI_CAMERA_JPEG_ENABLED=0 python3 pi/gateway.py & \
+	BACKEND_WS_BASE=ws://$(HOST_IP):$(BACKEND_PORT) PI_DEVICE_ID=$(PI_DEVICE_ID) python3 pi/webrtc_publisher.py & \
+	wait
 
 pi-backend-check:
 	@if [ -z "$(HOST_IP)" ]; then \

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Browser-based robot control app with directional controls, backend command routi
 Pi telemetry, dual Pi camera streaming, session recording for LiDAR plus both
 camera feeds, and optional ESP32 serial bridging.
 
+WebRTC video first pass: [docs/webrtc-video-first-pass.md](./docs/webrtc-video-first-pass.md)
+
 ## Current Tested Setup
 
 The most reliable development path in this repo is:

--- a/backend/README.md
+++ b/backend/README.md
@@ -151,6 +151,15 @@ Message types:
 - Backend -> UI: `snapshot`, `pi:event`, `pi:status`, `pi:ack`, `command:accepted`, `command:delivered`, `camera:frame`, `recording:status`
 - Backend -> Pi: `ui:command`
 
+WebRTC signaling path: `/webrtc`
+
+- Pi publisher connect: `/webrtc?role=pi&deviceId=pi-01&token=<PI_DEVICE_TOKEN>`
+- Browser viewer connect: `/webrtc?role=viewer&deviceId=pi-01`
+- Signaling messages: `viewer:ready`, `webrtc:offer`, `webrtc:answer`, `webrtc:ice`
+- The backend relays only signaling. WebRTC video media flows peer-to-peer.
+
+See [WebRTC Video First Pass](../docs/webrtc-video-first-pass.md) for the run flow.
+
 ## Common Development Topology
 
 The currently documented development flow is:

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -72,6 +72,8 @@ const state = {
 
 const uiClients = new Set();
 const piClients = new Map();
+const webrtcPiClients = new Map();
+const webrtcViewerClients = new Map();
 const recordingSessions = new Map();
 
 function nowIso() {
@@ -765,6 +767,234 @@ function getRemoteAddress(request) {
   return request.socket?.remoteAddress || "unknown";
 }
 
+function getWebRtcPiSocket(deviceId) {
+  return webrtcPiClients.get(deviceId) || null;
+}
+
+function getWebRtcViewer(viewerId) {
+  return webrtcViewerClients.get(viewerId) || null;
+}
+
+function getWebRtcViewersForDevice(deviceId) {
+  return Array.from(webrtcViewerClients.values()).filter((client) => client.deviceId === deviceId);
+}
+
+function summarizeIceCandidate(candidate) {
+  if (!candidate) return "end-of-candidates";
+  const candidateLine = String(candidate.candidate || "").trim();
+  if (!candidateLine) return "empty-candidate";
+
+  const tokens = candidateLine.replace(/^candidate:/, "").split(/\s+/);
+  const foundation = tokens[0] || "-";
+  const component = tokens[1] || "-";
+  const protocol = tokens[2] || "-";
+  const ip = tokens[4] || "-";
+  const port = tokens[5] || "-";
+  const typeIndex = tokens.indexOf("typ");
+  const candidateType = typeIndex >= 0 ? tokens[typeIndex + 1] || "-" : "-";
+  return `foundation=${foundation} component=${component} protocol=${protocol} address=${ip}:${port} type=${candidateType}`;
+}
+
+function logWebRtcSdp(direction, deviceId, viewerId, sdp) {
+  const description = isObject(sdp) ? sdp : {};
+  const descriptionType = String(description.type || "-");
+  const sdpText = String(description.sdp || "");
+  console.log(
+    `[webrtc] ${direction} SDP type=${descriptionType} deviceId=${deviceId} viewerId=${viewerId} bytes=${sdpText.length}`
+  );
+  if (sdpText) {
+    console.log(`[webrtc] ${direction} SDP body deviceId=${deviceId} viewerId=${viewerId}\n${sdpText}`);
+  }
+}
+
+function logWebRtcIce(direction, deviceId, viewerId, candidate) {
+  console.log(`[webrtc] ${direction} ICE deviceId=${deviceId} viewerId=${viewerId} ${summarizeIceCandidate(candidate)}`);
+}
+
+function logWebRtcConnection(message, deviceId, viewerId = "-") {
+  console.log(`[webrtc] ${message} deviceId=${deviceId} viewerId=${viewerId}`);
+}
+
+function sendWebRtcPiStatus(deviceId, status) {
+  for (const client of getWebRtcViewersForDevice(deviceId)) {
+    safeJsonSend(client.socket, {
+      type: "pi:webrtc-status",
+      deviceId,
+      status,
+      at: nowIso()
+    });
+  }
+}
+
+function registerWebRtcPiSocket(socket, deviceId) {
+  const existing = getWebRtcPiSocket(deviceId);
+  if (isSocketOpen(existing)) {
+    closeSocket(existing, WS_SERVICE_RESTART, "replaced by a new WebRTC publisher");
+  }
+
+  webrtcPiClients.set(deviceId, socket);
+  logWebRtcConnection("pi signaling connected", deviceId);
+  safeJsonSend(socket, {
+    type: "signal:ready",
+    role: "pi",
+    deviceId,
+    serverTime: nowIso()
+  });
+
+  for (const client of getWebRtcViewersForDevice(deviceId)) {
+    safeJsonSend(client.socket, {
+      type: "pi:webrtc-status",
+      deviceId,
+      status: "online",
+      at: nowIso()
+    });
+    safeJsonSend(socket, {
+      type: "viewer:connected",
+      deviceId,
+      viewerId: client.viewerId,
+      at: nowIso()
+    });
+  }
+}
+
+function registerWebRtcViewerSocket(socket, deviceId) {
+  const viewerId = crypto.randomUUID();
+  const piSocket = getWebRtcPiSocket(deviceId);
+  const piConnected = isSocketOpen(piSocket);
+
+  webrtcViewerClients.set(viewerId, {
+    viewerId,
+    deviceId,
+    socket,
+    connectedAt: nowIso()
+  });
+
+  logWebRtcConnection("viewer signaling connected", deviceId, viewerId);
+  safeJsonSend(socket, {
+    type: "signal:ready",
+    role: "viewer",
+    deviceId,
+    viewerId,
+    piConnected,
+    serverTime: nowIso()
+  });
+  safeJsonSend(socket, {
+    type: "pi:webrtc-status",
+    deviceId,
+    status: piConnected ? "online" : "offline",
+    at: nowIso()
+  });
+
+  if (piConnected) {
+    safeJsonSend(piSocket, {
+      type: "viewer:connected",
+      deviceId,
+      viewerId,
+      at: nowIso()
+    });
+  }
+
+  return viewerId;
+}
+
+function forwardWebRtcToPi(viewerId, message) {
+  const client = getWebRtcViewer(viewerId);
+  if (!client) return;
+
+  const piSocket = getWebRtcPiSocket(client.deviceId);
+  if (!isSocketOpen(piSocket)) {
+    safeJsonSend(client.socket, {
+      type: "pi:webrtc-status",
+      deviceId: client.deviceId,
+      status: "offline",
+      at: nowIso()
+    });
+    return;
+  }
+
+  const forwarded = {
+    ...message,
+    deviceId: client.deviceId,
+    viewerId
+  };
+
+  if (message.type === "webrtc:answer") {
+    logWebRtcSdp("viewer->pi", client.deviceId, viewerId, message.sdp);
+  } else if (message.type === "webrtc:ice") {
+    logWebRtcIce("viewer->pi", client.deviceId, viewerId, message.candidate || null);
+  } else {
+    logWebRtcConnection(`viewer->pi ${message.type}`, client.deviceId, viewerId);
+  }
+
+  safeJsonSend(piSocket, forwarded);
+}
+
+function forwardWebRtcToViewer(deviceId, viewerId, message) {
+  const client = getWebRtcViewer(viewerId);
+  if (!client || client.deviceId !== deviceId) return;
+
+  if (message.type === "webrtc:offer") {
+    logWebRtcSdp("pi->viewer", deviceId, viewerId, message.sdp);
+  } else if (message.type === "webrtc:ice") {
+    logWebRtcIce("pi->viewer", deviceId, viewerId, message.candidate || null);
+  } else {
+    logWebRtcConnection(`pi->viewer ${message.type}`, deviceId, viewerId);
+  }
+
+  safeJsonSend(client.socket, {
+    ...message,
+    deviceId,
+    viewerId
+  });
+}
+
+function handleWebRtcPiMessage(deviceId, message) {
+  if (!isObject(message)) return;
+
+  const viewerId = String(message.viewerId || "").trim();
+  if (!viewerId) return;
+
+  if (["webrtc:offer", "webrtc:ice", "webrtc:error"].includes(message.type)) {
+    forwardWebRtcToViewer(deviceId, viewerId, message);
+  }
+}
+
+function handleWebRtcViewerMessage(viewerId, message) {
+  if (!isObject(message)) return;
+
+  if (["viewer:ready", "webrtc:answer", "webrtc:ice"].includes(message.type)) {
+    forwardWebRtcToPi(viewerId, message);
+  }
+}
+
+function handleWebRtcSocketClose(role, socket, deviceId, viewerId) {
+  if (role === "pi") {
+    if (getWebRtcPiSocket(deviceId) === socket) {
+      webrtcPiClients.delete(deviceId);
+      logWebRtcConnection("pi signaling disconnected", deviceId);
+      sendWebRtcPiStatus(deviceId, "offline");
+    }
+    return;
+  }
+
+  if (role === "viewer") {
+    const client = getWebRtcViewer(viewerId);
+    if (client?.socket !== socket) return;
+
+    webrtcViewerClients.delete(viewerId);
+    logWebRtcConnection("viewer signaling disconnected", deviceId, viewerId);
+    const piSocket = getWebRtcPiSocket(deviceId);
+    if (isSocketOpen(piSocket)) {
+      safeJsonSend(piSocket, {
+        type: "viewer:disconnected",
+        deviceId,
+        viewerId,
+        at: nowIso()
+      });
+    }
+  }
+}
+
 function requirePiAuth(req, res, next) {
   if (!config.piDeviceToken) {
     next();
@@ -785,7 +1015,9 @@ app.get("/health", (req, res) => {
     ok: true,
     uptimeSeconds: Math.floor(process.uptime()),
     connectedUiClients: uiClients.size,
-    connectedPiClients: piClients.size
+    connectedPiClients: piClients.size,
+    connectedWebRtcPiClients: webrtcPiClients.size,
+    connectedWebRtcViewerClients: webrtcViewerClients.size
   });
 });
 
@@ -1090,7 +1322,28 @@ function handleSocketClose(role, socket, deviceId) {
 }
 
 const server = http.createServer(app);
-const wsServer = new WebSocketServer({ server, path: "/ws" });
+const wsServer = new WebSocketServer({ noServer: true });
+const webrtcSignalingServer = new WebSocketServer({ noServer: true });
+
+server.on("upgrade", (request, socket, head) => {
+  const requestUrl = new URL(request.url || "/", `http://${request.headers.host}`);
+  let targetServer = null;
+  if (requestUrl.pathname === "/ws") {
+    targetServer = wsServer;
+  } else if (requestUrl.pathname === "/webrtc") {
+    targetServer = webrtcSignalingServer;
+  }
+
+  if (!targetServer) {
+    socket.write("HTTP/1.1 404 Not Found\r\n\r\n");
+    socket.destroy();
+    return;
+  }
+
+  targetServer.handleUpgrade(request, socket, head, (webSocket) => {
+    targetServer.emit("connection", webSocket, request);
+  });
+});
 
 wsServer.on("connection", (socket, request) => {
   const requestUrl = new URL(request.url || "/", `http://${request.headers.host}`);
@@ -1142,6 +1395,57 @@ wsServer.on("connection", (socket, request) => {
       console.log(`ui disconnected remote=${remoteAddress}`);
     }
     handleSocketClose(role, socket, deviceId);
+  });
+});
+
+webrtcSignalingServer.on("connection", (socket, request) => {
+  const requestUrl = new URL(request.url || "/", `http://${request.headers.host}`);
+  const role = requestUrl.searchParams.get("role");
+  const deviceId = String(requestUrl.searchParams.get("deviceId") || "").trim();
+  const token = extractRequestToken(requestUrl, request);
+  const remoteAddress = getRemoteAddress(request);
+  let viewerId = "";
+
+  if (!deviceId) {
+    console.warn(`[webrtc] socket rejected remote=${remoteAddress} reason=missing_device_id`);
+    closeSocket(socket, WS_POLICY_VIOLATION, "deviceId is required");
+    return;
+  }
+
+  if (role === "pi") {
+    if (config.piDeviceToken && token !== config.piDeviceToken) {
+      console.warn(`[webrtc] pi rejected remote=${remoteAddress} deviceId=${deviceId} reason=invalid_device_token`);
+      closeSocket(socket, WS_POLICY_VIOLATION, "invalid device token");
+      return;
+    }
+
+    console.log(`[webrtc] pi signaling accepted remote=${remoteAddress} deviceId=${deviceId}`);
+    registerWebRtcPiSocket(socket, deviceId);
+  } else if (role === "viewer") {
+    console.log(`[webrtc] viewer signaling accepted remote=${remoteAddress} deviceId=${deviceId}`);
+    viewerId = registerWebRtcViewerSocket(socket, deviceId);
+  } else {
+    console.warn(`[webrtc] socket rejected remote=${remoteAddress} reason=invalid_role role=${role || "-"}`);
+    closeSocket(socket, WS_POLICY_VIOLATION, "role must be pi or viewer");
+    return;
+  }
+
+  socket.on("message", (rawData) => {
+    const message = parseJsonMessage(rawData);
+    if (!message) return;
+
+    if (role === "pi") {
+      handleWebRtcPiMessage(deviceId, message);
+      return;
+    }
+
+    if (role === "viewer") {
+      handleWebRtcViewerMessage(viewerId, message);
+    }
+  });
+
+  socket.on("close", () => {
+    handleWebRtcSocketClose(role, socket, deviceId, viewerId);
   });
 });
 

--- a/docs/webrtc-video-first-pass.md
+++ b/docs/webrtc-video-first-pass.md
@@ -1,0 +1,207 @@
+# WebRTC Video First Pass
+
+This is the first minimal WebRTC video path for the robot. It keeps the
+existing control and telemetry path on the current backend `/ws` socket, and
+adds a separate WebRTC signaling socket at `/webrtc`.
+
+## Architecture Overview
+
+```text
+Browser
+  web/app.js
+  - /ws?role=ui                         existing controls, telemetry, LiDAR
+  - /webrtc?role=viewer&deviceId=pi-01  WebRTC signaling only
+  - RTCPeerConnection                   receives one live video track
+
+PC backend
+  backend/src/server.js
+  - /ws                                 existing app protocol
+  - /webrtc                             WebSocket signaling relay
+  - no video media passes through this server
+
+Raspberry Pi
+  pi/gateway.py
+  - existing controls, motor status, LiDAR, temperature
+  - run with PI_CAMERA_JPEG_ENABLED=0 for the WebRTC path
+
+  pi/webrtc_publisher.py
+  - connects to /webrtc as role=pi
+  - creates one RTCPeerConnection per browser viewer
+  - publishes one camera track from pi/webrtc_camera.py
+```
+
+The first negotiation flow is:
+
+1. Browser opens `/webrtc?role=viewer&deviceId=pi-01`.
+2. Pi publisher opens `/webrtc?role=pi&deviceId=pi-01`.
+3. Browser sends `viewer:ready`.
+4. Pi creates an offer with one video track and sends `webrtc:offer`.
+5. Browser creates an answer and sends `webrtc:answer`.
+6. Browser and Pi log SDP, ICE candidates, ICE state, signaling state, and peer
+   connection state.
+
+## Dependency List
+
+PC backend:
+
+- Node `>=18`
+- Existing backend packages: `express`, `cors`, `dotenv`, `ws`
+
+Browser:
+
+- A browser with native WebRTC support
+- No new frontend package dependency
+
+Raspberry Pi:
+
+- Existing Pi packages from `pi/requirements.txt`
+- `aiortc>=1.14.0`
+- `Pillow>=10.0.0`
+- Preferred camera command: `rpicam-vid` or `libcamera-vid`
+- Optional fallback camera package: `python3-opencv`
+
+## File Structure
+
+```text
+backend/src/server.js       existing backend plus /webrtc signaling relay
+web/index.html              main video element for WebRTC playback
+web/app.js                  browser WebRTC signaling and peer connection code
+pi/gateway.py               existing Pi gateway plus PI_CAMERA_JPEG_ENABLED
+pi/webrtc_camera.py         rpicam/libcamera and OpenCV aiortc video tracks
+pi/webrtc_publisher.py      Pi-side WebRTC publisher
+pi/requirements.txt         Pi Python dependencies
+Makefile                    run targets for the first WebRTC path
+```
+
+## Run Steps
+
+### 1. Start the PC backend and web app
+
+From the repo root on the PC:
+
+```bash
+make pc-setup
+make pc-start
+```
+
+This starts:
+
+- backend: `http://0.0.0.0:3000`
+- web app: `http://127.0.0.1:8080`
+
+### 2. Prepare the Pi environment
+
+From the repo root on the Pi:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+make pi-setup
+```
+
+If the Pi does not have `rpicam-vid` or `libcamera-vid`, install the OpenCV
+fallback:
+
+```bash
+sudo apt-get install -y python3-opencv
+```
+
+### 3. Run controls plus WebRTC video from the Pi
+
+Echo/no-hardware controls:
+
+```bash
+make pi-connect-webrtc-echo PC_IP=<pc-ip-or-tailscale-ip>
+```
+
+Direct ESC controls:
+
+```bash
+make pi-connect-webrtc-esc PC_IP=<pc-ip-or-tailscale-ip>
+```
+
+Those targets start two Pi processes:
+
+- `pi/gateway.py` for the existing controls and telemetry path
+- `pi/webrtc_publisher.py` for the new one-camera WebRTC video path
+
+They also set `PI_CAMERA_JPEG_ENABLED=0` so the old JPEG frame sender does not
+open the camera at the same time as the WebRTC publisher.
+
+### 4. Open the browser
+
+On the PC:
+
+```text
+http://127.0.0.1:8080?deviceId=pi-01
+```
+
+From another machine on the same network:
+
+```text
+http://<pc-ip>:8080?backendHost=<pc-ip>&deviceId=pi-01
+```
+
+### 5. Useful WebRTC knobs
+
+```bash
+WEBRTC_CAMERA_INDEX=0
+WEBRTC_CAMERA_BACKEND=auto     # auto | rpicam | opencv
+WEBRTC_CAMERA_WIDTH=960
+WEBRTC_CAMERA_HEIGHT=720
+WEBRTC_CAMERA_FPS=15
+WEBRTC_CAMERA_JPEG_QUALITY=70
+WEBRTC_LOG_SDP=1
+```
+
+Browser query-string overrides:
+
+```text
+?webrtc=0                     disables the WebRTC client path
+?webrtcWs=<url-encoded-signaling-url>
+```
+
+## Logging
+
+Backend logs use the `[webrtc]` prefix and include:
+
+- signaling connects and disconnects
+- SDP offer/answer type and full SDP body
+- ICE candidate summaries
+
+Pi publisher logs include:
+
+- local offer SDP
+- remote answer SDP
+- local ICE candidates embedded in SDP
+- remote ICE candidates from the browser
+- peer connection, ICE connection, ICE gathering, and signaling state
+
+Browser logs include:
+
+- signaling socket status
+- remote offer SDP
+- local answer SDP
+- local and remote ICE candidates
+- peer connection, ICE connection, ICE gathering, and signaling state
+
+## Current Limits
+
+- One camera only: front camera index `0` by default.
+- Robot controls still use the existing backend `/ws` path.
+- The backend does not forward video media. It only forwards signaling.
+- Backend-managed camera recording still depends on the old JPEG frame path and
+  is not part of this first WebRTC slice.
+- TURN server support is not wired yet.
+
+## Next-Step Plan
+
+1. Add `RTCDataChannel` for control and telemetry after the video path is stable.
+   Keep `/ws` controls as fallback during the migration.
+2. Add a second camera by creating a second camera track in `pi/webrtc_publisher.py`
+   and a second `<video>` attachment in `web/app.js`.
+3. Add TURN/STUN configuration to both the browser `RTCPeerConnection` and the
+   Pi publisher `RTCPeerConnection`.
+4. Add camera switching by signaling the desired camera over the existing control
+   path first, then later over the data channel.
+5. Move recording to WebRTC-compatible capture after the live path is reliable.

--- a/pi/README.md
+++ b/pi/README.md
@@ -13,6 +13,11 @@ Responsibilities:
 - Stream live JPEG frames for both configured Pi cameras to the frontend.
 - Stream live LiDAR scans (`lidar.scan`) to backend for web rendering.
 
+The first WebRTC video path runs as a separate Pi publisher process:
+`pi/webrtc_publisher.py`. Use `PI_CAMERA_JPEG_ENABLED=0` on `gateway.py` when
+the WebRTC publisher owns the camera. See
+[WebRTC Video First Pass](../docs/webrtc-video-first-pass.md).
+
 ## Install
 
 From the repo root on the Pi:
@@ -208,6 +213,12 @@ The ESP firmware interprets ANSI arrow escape sequences, so this script sends
 - `CAMERA_FRAME_WIDTH` default: `960`
 - `CAMERA_FRAME_HEIGHT` default: `720`
 - `CAMERA_JPEG_QUALITY` default: `60`
+- `PI_CAMERA_JPEG_ENABLED` default: `1` (set `0` when `pi/webrtc_publisher.py` owns the camera)
+- `WEBRTC_CAMERA_INDEX` default: `CAMERA_FRONT_INDEX` / `0`
+- `WEBRTC_CAMERA_BACKEND` default: `auto`, supported values: `auto`, `rpicam`, `opencv`
+- `WEBRTC_CAMERA_WIDTH` / `WEBRTC_CAMERA_HEIGHT` default to `CAMERA_FRAME_WIDTH` / `CAMERA_FRAME_HEIGHT`
+- `WEBRTC_CAMERA_FPS` default: `15`
+- `WEBRTC_LOG_SDP` default: `1`
 - `LIDAR_ENABLED` default: `1` (set `0` to disable streaming)
 - `LIDAR_SERIAL_PORT` default: `/dev/ttyUSB1` when `PI_MOTOR_DRIVER=esp`, otherwise `/dev/ttyUSB0`
 - `LIDAR_MAX_DISTANCE_MM` default: `6000`

--- a/pi/gateway.py
+++ b/pi/gateway.py
@@ -139,6 +139,7 @@ class Config:
     camera_frame_width: int
     camera_frame_height: int
     camera_jpeg_quality: int
+    camera_jpeg_enabled: bool
     lidar_enabled: bool
     lidar_port: str
     lidar_max_distance_mm: int
@@ -196,6 +197,7 @@ class Config:
             camera_frame_width=env_int("CAMERA_FRAME_WIDTH", 960),
             camera_frame_height=env_int("CAMERA_FRAME_HEIGHT", 720),
             camera_jpeg_quality=env_int("CAMERA_JPEG_QUALITY", 60),
+            camera_jpeg_enabled=env_flag("PI_CAMERA_JPEG_ENABLED", default=True),
             lidar_enabled=env_flag("LIDAR_ENABLED", default=True),
             lidar_port=os.getenv("LIDAR_SERIAL_PORT", lidar_default_port),
             lidar_max_distance_mm=env_int("LIDAR_MAX_DISTANCE_MM", 6000),
@@ -1034,8 +1036,14 @@ class CameraManager:
         frame_height: int,
         stream_hz: float,
         jpeg_quality: int,
+        enabled: bool = True,
     ) -> None:
         self.stream_hz = clamp_camera_stream_hz(stream_hz)
+        self.enabled = enabled
+        if not self.enabled:
+            self._workers: Dict[str, CameraWorker] = {}
+            return
+
         camera_commands = find_camera_stream_command()
         self._workers = {
             "front": CameraWorker(
@@ -1089,6 +1097,7 @@ class CameraManager:
 
     def snapshot(self) -> JsonDict:
         return {
+            "jpegEnabled": self.enabled,
             "streamHz": round(self.stream_hz, 2),
             "minStreamHz": CAMERA_STREAM_HZ_MIN,
             "maxStreamHz": CAMERA_STREAM_HZ_MAX,
@@ -1426,6 +1435,7 @@ class PiGateway:
             frame_height=config.camera_frame_height,
             stream_hz=config.camera_stream_hz,
             jpeg_quality=config.camera_jpeg_quality,
+            enabled=config.camera_jpeg_enabled,
         )
         self.temperature = PiTemperatureReader()
         self.lidar = LidarBridge(
@@ -1547,6 +1557,7 @@ class PiGateway:
                     "motorDriver": self.config.motor_driver,
                     "motorEcho": self.config.motor_echo,
                     "motorEchoOnly": self.config.motor_echo_only,
+                    "cameraJpegEnabled": self.config.camera_jpeg_enabled,
                     "cameraIndexes": [self.config.camera_front_index, self.config.camera_back_index],
                     "cameraStreamHz": self.cameras.stream_hz,
                     "cameraFrameSize": [self.config.camera_frame_width, self.config.camera_frame_height],
@@ -1968,11 +1979,12 @@ async def async_main() -> None:
     )
     config = Config.from_env()
     logging.info(
-        "Pi gateway starting deviceId=%s backend=%s motorDriver=%s lidarEnabled=%s",
+        "Pi gateway starting deviceId=%s backend=%s motorDriver=%s lidarEnabled=%s cameraJpegEnabled=%s",
         config.device_id,
         config.ws_url,
         config.motor_driver,
         config.lidar_enabled,
+        config.camera_jpeg_enabled,
     )
     gateway = PiGateway(config)
     try:

--- a/pi/requirements.txt
+++ b/pi/requirements.txt
@@ -1,4 +1,6 @@
 pyserial>=3.5
 websockets>=12.0
+aiortc>=1.14.0
+Pillow>=10.0.0
 rplidar-roboticia==0.9.5
 pigpio>=1.78

--- a/pi/webrtc_camera.py
+++ b/pi/webrtc_camera.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""
+Camera tracks for the first WebRTC video path.
+
+The preferred Raspberry Pi path is rpicam/libcamera producing MJPEG on stdout.
+Each JPEG is decoded into a PyAV VideoFrame, which aiortc then encodes for the
+browser peer connection.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import logging
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass
+from typing import List, Optional
+
+from aiortc import VideoStreamTrack
+from aiortc.mediastreams import MediaStreamError
+from av import VideoFrame
+from PIL import Image
+
+try:
+    import cv2  # type: ignore
+except ImportError:  # pragma: no cover
+    cv2 = None
+
+
+JPEG_SOI = b"\xff\xd8"
+JPEG_EOI = b"\xff\xd9"
+
+
+@dataclass(frozen=True)
+class CameraTrackConfig:
+    backend: str
+    camera_index: int
+    width: int
+    height: int
+    fps: float
+    jpeg_quality: int
+
+
+def clamp_int(value: int, minimum: int, maximum: int) -> int:
+    return max(minimum, min(maximum, value))
+
+
+def clamp_float(value: float, minimum: float, maximum: float) -> float:
+    return max(minimum, min(maximum, value))
+
+
+def find_rpicam_command() -> Optional[str]:
+    for command in ("rpicam-vid", "libcamera-vid"):
+        if shutil.which(command):
+            return command
+    return None
+
+
+def create_camera_track(config: CameraTrackConfig) -> VideoStreamTrack:
+    backend = config.backend.strip().lower() or "auto"
+    if backend not in {"auto", "rpicam", "opencv"}:
+        raise ValueError("camera backend must be one of auto|rpicam|opencv")
+
+    rpicam_command = find_rpicam_command()
+    if backend in {"auto", "rpicam"} and rpicam_command:
+        return RpicamMjpegCameraTrack(config=config, command_name=rpicam_command)
+
+    if backend == "rpicam":
+        raise RuntimeError("rpicam/libcamera command not found")
+
+    if backend in {"auto", "opencv"} and cv2 is not None:
+        return OpenCvCameraTrack(config=config)
+
+    raise RuntimeError("no WebRTC camera backend available; install rpicam/libcamera or python3-opencv")
+
+
+class RpicamMjpegCameraTrack(VideoStreamTrack):
+    kind = "video"
+
+    def __init__(self, config: CameraTrackConfig, command_name: str) -> None:
+        super().__init__()
+        self.config = config
+        self.command_name = command_name
+        self._buffer = bytearray()
+        self._process: Optional[asyncio.subprocess.Process] = None
+        self._started_once = False
+
+    def _build_command(self) -> List[str]:
+        return [
+            self.command_name,
+            "--camera",
+            str(self.config.camera_index),
+            "--nopreview",
+            "--codec",
+            "mjpeg",
+            "--timeout",
+            "0",
+            "--framerate",
+            f"{clamp_float(self.config.fps, 1.0, 60.0):.2f}",
+            "--width",
+            str(max(160, self.config.width)),
+            "--height",
+            str(max(120, self.config.height)),
+            "--quality",
+            str(clamp_int(self.config.jpeg_quality, 20, 95)),
+            "--output",
+            "-",
+        ]
+
+    async def _ensure_process(self) -> asyncio.subprocess.Process:
+        if self._process is not None and self._process.returncode is None:
+            return self._process
+
+        command = self._build_command()
+        if not self._started_once:
+            logging.info("WebRTC camera starting via %s", " ".join(command))
+            self._started_once = True
+        else:
+            logging.warning("WebRTC camera restarting via %s", self.command_name)
+
+        self._buffer.clear()
+        self._process = await asyncio.create_subprocess_exec(
+            *command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+        if self._process.stdout is None:
+            self._terminate_process()
+            raise RuntimeError("camera process did not expose stdout")
+        return self._process
+
+    def _terminate_process(self) -> None:
+        process = self._process
+        self._process = None
+        if process is None or process.returncode is not None:
+            return
+
+        try:
+            process.terminate()
+        except ProcessLookupError:
+            return
+
+    @staticmethod
+    def _extract_jpeg(buffer: bytearray) -> Optional[bytes]:
+        while True:
+            start_index = buffer.find(JPEG_SOI)
+            if start_index < 0:
+                if len(buffer) > 1:
+                    del buffer[:-1]
+                return None
+
+            if start_index > 0:
+                del buffer[:start_index]
+
+            end_index = buffer.find(JPEG_EOI, 2)
+            if end_index < 0:
+                return None
+
+            frame = bytes(buffer[: end_index + 2])
+            del buffer[: end_index + 2]
+            if len(frame) >= 1024:
+                return frame
+
+    @staticmethod
+    def _decode_jpeg(jpeg_bytes: bytes) -> VideoFrame:
+        image = Image.open(io.BytesIO(jpeg_bytes))
+        image.load()
+        if image.mode != "RGB":
+            image = image.convert("RGB")
+        return VideoFrame.from_image(image)
+
+    async def _read_jpeg(self) -> bytes:
+        while self.readyState == "live":
+            process = await self._ensure_process()
+            assert process.stdout is not None
+            chunk = await process.stdout.read(65536)
+            if not chunk:
+                return_code = process.returncode
+                self._terminate_process()
+                logging.warning("WebRTC camera process ended with code %s", return_code)
+                await asyncio.sleep(0.5)
+                continue
+
+            self._buffer.extend(chunk)
+            frame = self._extract_jpeg(self._buffer)
+            if frame:
+                return frame
+
+        raise MediaStreamError
+
+    async def recv(self) -> VideoFrame:
+        while self.readyState == "live":
+            jpeg_bytes = await self._read_jpeg()
+            try:
+                frame = self._decode_jpeg(jpeg_bytes)
+            except Exception as exc:
+                logging.warning("WebRTC camera JPEG decode failed: %s", exc)
+                continue
+
+            pts, time_base = await self.next_timestamp()
+            frame.pts = pts
+            frame.time_base = time_base
+            return frame
+
+        raise MediaStreamError
+
+    def stop(self) -> None:
+        self._terminate_process()
+        super().stop()
+
+
+class OpenCvCameraTrack(VideoStreamTrack):
+    kind = "video"
+
+    def __init__(self, config: CameraTrackConfig) -> None:
+        super().__init__()
+        self.config = config
+        self._capture: Optional[object] = None
+        self._last_frame_monotonic = 0.0
+
+    def _open_capture(self) -> object:
+        if cv2 is None:
+            raise RuntimeError("OpenCV is not installed")
+
+        capture = cv2.VideoCapture(self.config.camera_index)
+        if not capture.isOpened():
+            capture.release()
+            raise RuntimeError(f"OpenCV could not open camera index {self.config.camera_index}")
+
+        capture.set(cv2.CAP_PROP_FRAME_WIDTH, float(max(160, self.config.width)))
+        capture.set(cv2.CAP_PROP_FRAME_HEIGHT, float(max(120, self.config.height)))
+        capture.set(cv2.CAP_PROP_FPS, float(clamp_float(self.config.fps, 1.0, 60.0)))
+        logging.info("WebRTC camera starting via OpenCV index=%s", self.config.camera_index)
+        return capture
+
+    def _ensure_capture(self) -> object:
+        if self._capture is None:
+            self._capture = self._open_capture()
+        return self._capture
+
+    def _release_capture(self) -> None:
+        capture = self._capture
+        self._capture = None
+        if capture is not None:
+            close = getattr(capture, "release", None)
+            if callable(close):
+                close()
+
+    def _read_frame(self) -> VideoFrame:
+        capture = self._ensure_capture()
+        ok, image = capture.read()
+        if not ok or image is None:
+            self._release_capture()
+            raise RuntimeError("OpenCV camera read failed")
+        return VideoFrame.from_ndarray(image, format="bgr24")
+
+    async def _pace(self) -> None:
+        interval_sec = 1.0 / clamp_float(self.config.fps, 1.0, 60.0)
+        next_frame_at = self._last_frame_monotonic + interval_sec
+        sleep_sec = max(0.0, next_frame_at - time.monotonic())
+        if sleep_sec:
+            await asyncio.sleep(sleep_sec)
+        self._last_frame_monotonic = time.monotonic()
+
+    async def recv(self) -> VideoFrame:
+        while self.readyState == "live":
+            await self._pace()
+            try:
+                frame = await asyncio.to_thread(self._read_frame)
+            except Exception as exc:
+                logging.warning("WebRTC OpenCV camera read failed: %s", exc)
+                await asyncio.sleep(0.5)
+                continue
+
+            pts, time_base = await self.next_timestamp()
+            frame.pts = pts
+            frame.time_base = time_base
+            return frame
+
+        raise MediaStreamError
+
+    def stop(self) -> None:
+        self._release_capture()
+        super().stop()

--- a/pi/webrtc_publisher.py
+++ b/pi/webrtc_publisher.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""
+Minimal Raspberry Pi WebRTC video publisher.
+
+This process connects to the backend /webrtc WebSocket as role=pi, creates one
+RTCPeerConnection per browser viewer, and publishes one camera track.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+from urllib.parse import urlencode
+
+import websockets
+from websockets.exceptions import ConnectionClosed
+
+from aiortc import RTCIceCandidate, RTCPeerConnection, RTCSessionDescription
+from aiortc.contrib.media import MediaRelay
+
+from webrtc_camera import CameraTrackConfig, create_camera_track
+
+
+JsonDict = Dict[str, Any]
+
+
+def env_flag(name: str, default: bool = False) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() not in {"0", "false", "no", "off", ""}
+
+
+def env_int(name: str, default: int) -> int:
+    return int(os.getenv(name, str(default)))
+
+
+def env_float(name: str, default: float) -> float:
+    return float(os.getenv(name, str(default)))
+
+
+def env_int_any(names: tuple[str, ...], default: int) -> int:
+    for name in names:
+        raw = os.getenv(name)
+        if raw is not None:
+            return int(raw)
+    return default
+
+
+def parse_json_message(raw: Any) -> Optional[JsonDict]:
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+@dataclass(frozen=True)
+class Config:
+    signaling_ws_base: str
+    device_id: str
+    device_token: str
+    reconnect_max_sec: float
+    log_sdp: bool
+    camera_backend: str
+    camera_index: int
+    camera_width: int
+    camera_height: int
+    camera_fps: float
+    camera_jpeg_quality: int
+
+    @property
+    def signaling_url(self) -> str:
+        base = self.signaling_ws_base.rstrip("/")
+        params = {"role": "pi", "deviceId": self.device_id}
+        if self.device_token:
+            params["token"] = self.device_token
+        return f"{base}/webrtc?{urlencode(params)}"
+
+    @staticmethod
+    def from_env() -> "Config":
+        backend_ws_base = os.getenv("BACKEND_WS_BASE", "ws://127.0.0.1:3000")
+        frame_width = env_int("CAMERA_FRAME_WIDTH", 960)
+        frame_height = env_int("CAMERA_FRAME_HEIGHT", 720)
+        return Config(
+            signaling_ws_base=os.getenv("WEBRTC_SIGNALING_WS_BASE", backend_ws_base),
+            device_id=os.getenv("PI_DEVICE_ID", "pi-01"),
+            device_token=os.getenv("PI_DEVICE_TOKEN", ""),
+            reconnect_max_sec=env_float("PI_RECONNECT_MAX_SEC", 20.0),
+            log_sdp=env_flag("WEBRTC_LOG_SDP", default=True),
+            camera_backend=os.getenv("WEBRTC_CAMERA_BACKEND", "auto"),
+            camera_index=env_int_any(("WEBRTC_CAMERA_INDEX", "CAMERA_FRONT_INDEX", "CAMERA_LEFT_INDEX"), 0),
+            camera_width=env_int("WEBRTC_CAMERA_WIDTH", frame_width),
+            camera_height=env_int("WEBRTC_CAMERA_HEIGHT", frame_height),
+            camera_fps=env_float("WEBRTC_CAMERA_FPS", 15.0),
+            camera_jpeg_quality=env_int("WEBRTC_CAMERA_JPEG_QUALITY", env_int("CAMERA_JPEG_QUALITY", 70)),
+        )
+
+    def camera_track_config(self) -> CameraTrackConfig:
+        return CameraTrackConfig(
+            backend=self.camera_backend,
+            camera_index=self.camera_index,
+            width=self.camera_width,
+            height=self.camera_height,
+            fps=self.camera_fps,
+            jpeg_quality=self.camera_jpeg_quality,
+        )
+
+
+def describe_sdp(description: RTCSessionDescription) -> str:
+    return f"type={description.type} bytes={len(description.sdp or '')}"
+
+
+def summarize_candidate_line(candidate_line: str) -> str:
+    candidate = candidate_line.strip().removeprefix("a=").removeprefix("candidate:")
+    if not candidate:
+        return "empty-candidate"
+
+    tokens = candidate.split()
+    foundation = tokens[0] if len(tokens) > 0 else "-"
+    component = tokens[1] if len(tokens) > 1 else "-"
+    protocol = tokens[2] if len(tokens) > 2 else "-"
+    ip = tokens[4] if len(tokens) > 4 else "-"
+    port = tokens[5] if len(tokens) > 5 else "-"
+    type_index = tokens.index("typ") if "typ" in tokens else -1
+    candidate_type = tokens[type_index + 1] if type_index >= 0 and len(tokens) > type_index + 1 else "-"
+    return f"foundation={foundation} component={component} protocol={protocol} address={ip}:{port} type={candidate_type}"
+
+
+def parse_browser_candidate(payload: Optional[JsonDict]) -> Optional[RTCIceCandidate]:
+    if not payload:
+        return None
+
+    candidate_text = str(payload.get("candidate") or "").strip()
+    if not candidate_text:
+        return None
+
+    tokens = candidate_text.removeprefix("candidate:").split()
+    if len(tokens) < 8 or tokens[6] != "typ":
+        raise ValueError(f"unsupported ICE candidate format: {candidate_text}")
+
+    related_address = None
+    related_port = None
+    tcp_type = None
+    index = 8
+    while index + 1 < len(tokens):
+        key = tokens[index]
+        value = tokens[index + 1]
+        if key == "raddr":
+            related_address = value
+        elif key == "rport":
+            related_port = int(value)
+        elif key == "tcptype":
+            tcp_type = value
+        index += 2
+
+    return RTCIceCandidate(
+        foundation=tokens[0],
+        component=int(tokens[1]),
+        protocol=tokens[2].lower(),
+        priority=int(tokens[3]),
+        ip=tokens[4],
+        port=int(tokens[5]),
+        type=tokens[7],
+        relatedAddress=related_address,
+        relatedPort=related_port,
+        sdpMid=payload.get("sdpMid"),
+        sdpMLineIndex=payload.get("sdpMLineIndex"),
+        tcpType=tcp_type,
+    )
+
+
+class WebRtcPublisher:
+    def __init__(self, config: Config) -> None:
+        self.config = config
+        self.relay = MediaRelay()
+        self.source_track = create_camera_track(config.camera_track_config())
+        self.peers: Dict[str, RTCPeerConnection] = {}
+        self.ws: Optional[Any] = None
+
+    async def run_forever(self) -> None:
+        backoff = 1.0
+        while True:
+            try:
+                await self._run_session()
+                backoff = 1.0
+            except Exception as exc:
+                logging.warning("WebRTC signaling session ended: %s", exc)
+                await self._close_all_peers()
+                await asyncio.sleep(backoff)
+                backoff = min(self.config.reconnect_max_sec, backoff * 2.0)
+
+    async def _run_session(self) -> None:
+        logging.info("Connecting to WebRTC signaling: %s", self.config.signaling_url)
+        async with websockets.connect(self.config.signaling_url, ping_interval=20, ping_timeout=20) as ws:
+            self.ws = ws
+            async for raw in ws:
+                message = parse_json_message(raw)
+                if message:
+                    await self._handle_message(message)
+
+    async def _send_json(self, payload: JsonDict) -> None:
+        if self.ws is None:
+            return
+        await self.ws.send(json.dumps(payload, separators=(",", ":")))
+
+    def _log_sdp(self, label: str, description: RTCSessionDescription, viewer_id: str) -> None:
+        logging.info("%s SDP viewerId=%s %s", label, viewer_id, describe_sdp(description))
+        if self.config.log_sdp:
+            logging.info("%s SDP body viewerId=%s\n%s", label, viewer_id, description.sdp)
+
+        for line in description.sdp.splitlines():
+            if line.startswith("a=candidate:"):
+                logging.info("%s ICE candidate viewerId=%s %s", label, viewer_id, summarize_candidate_line(line))
+            elif line == "a=end-of-candidates":
+                logging.info("%s ICE end-of-candidates viewerId=%s", label, viewer_id)
+
+    def _log_remote_candidate(self, viewer_id: str, candidate: Optional[JsonDict]) -> None:
+        if not candidate:
+            logging.info("Remote ICE end-of-candidates viewerId=%s", viewer_id)
+            return
+        logging.info(
+            "Remote ICE candidate viewerId=%s %s",
+            viewer_id,
+            summarize_candidate_line(str(candidate.get("candidate") or "")),
+        )
+
+    async def _wait_for_ice_complete(self, pc: RTCPeerConnection, viewer_id: str) -> None:
+        if pc.iceGatheringState == "complete":
+            return
+
+        done = asyncio.Event()
+
+        @pc.on("icegatheringstatechange")
+        def on_ice_gathering_state_change() -> None:
+            logging.info("ICE gathering state viewerId=%s state=%s", viewer_id, pc.iceGatheringState)
+            if pc.iceGatheringState == "complete":
+                done.set()
+
+        try:
+            await asyncio.wait_for(done.wait(), timeout=5.0)
+        except asyncio.TimeoutError:
+            logging.warning("ICE gathering timed out viewerId=%s state=%s", viewer_id, pc.iceGatheringState)
+
+    async def _create_peer(self, viewer_id: str) -> RTCPeerConnection:
+        await self._close_peer(viewer_id)
+        pc = RTCPeerConnection()
+        self.peers[viewer_id] = pc
+        pc.addTrack(self.relay.subscribe(self.source_track))
+
+        @pc.on("connectionstatechange")
+        async def on_connection_state_change() -> None:
+            logging.info("Peer connection state viewerId=%s state=%s", viewer_id, pc.connectionState)
+            if pc.connectionState in {"failed", "closed"}:
+                await self._close_peer(viewer_id)
+
+        @pc.on("iceconnectionstatechange")
+        async def on_ice_connection_state_change() -> None:
+            logging.info("ICE connection state viewerId=%s state=%s", viewer_id, pc.iceConnectionState)
+            if pc.iceConnectionState == "failed":
+                await self._close_peer(viewer_id)
+
+        @pc.on("signalingstatechange")
+        def on_signaling_state_change() -> None:
+            logging.info("Signaling state viewerId=%s state=%s", viewer_id, pc.signalingState)
+
+        logging.info("Created peer connection viewerId=%s", viewer_id)
+        return pc
+
+    async def _start_offer(self, viewer_id: str) -> None:
+        pc = await self._create_peer(viewer_id)
+        offer = await pc.createOffer()
+        await pc.setLocalDescription(offer)
+        await self._wait_for_ice_complete(pc, viewer_id)
+
+        description = pc.localDescription
+        self._log_sdp("Local offer", description, viewer_id)
+        await self._send_json(
+            {
+                "type": "webrtc:offer",
+                "viewerId": viewer_id,
+                "sdp": {
+                    "type": description.type,
+                    "sdp": description.sdp,
+                },
+            }
+        )
+
+    async def _handle_answer(self, viewer_id: str, payload: JsonDict) -> None:
+        pc = self.peers.get(viewer_id)
+        if pc is None:
+            logging.warning("Ignoring WebRTC answer for unknown viewerId=%s", viewer_id)
+            return
+
+        sdp = payload.get("sdp")
+        if not isinstance(sdp, dict):
+            logging.warning("Ignoring WebRTC answer with invalid SDP viewerId=%s", viewer_id)
+            return
+
+        description = RTCSessionDescription(sdp=str(sdp.get("sdp") or ""), type=str(sdp.get("type") or "answer"))
+        self._log_sdp("Remote answer", description, viewer_id)
+        await pc.setRemoteDescription(description)
+
+    async def _handle_remote_ice(self, viewer_id: str, payload: JsonDict) -> None:
+        pc = self.peers.get(viewer_id)
+        if pc is None:
+            logging.warning("Ignoring ICE for unknown viewerId=%s", viewer_id)
+            return
+
+        candidate_payload = payload.get("candidate")
+        if candidate_payload is not None and not isinstance(candidate_payload, dict):
+            logging.warning("Ignoring invalid ICE candidate viewerId=%s", viewer_id)
+            return
+
+        self._log_remote_candidate(viewer_id, candidate_payload)
+        candidate = parse_browser_candidate(candidate_payload)
+        await pc.addIceCandidate(candidate)
+
+    async def _close_peer(self, viewer_id: str) -> None:
+        pc = self.peers.pop(viewer_id, None)
+        if pc is None:
+            return
+        logging.info("Closing peer connection viewerId=%s", viewer_id)
+        await pc.close()
+
+    async def _close_all_peers(self) -> None:
+        viewer_ids = list(self.peers.keys())
+        await asyncio.gather(*(self._close_peer(viewer_id) for viewer_id in viewer_ids), return_exceptions=True)
+
+    async def _handle_message(self, message: JsonDict) -> None:
+        message_type = str(message.get("type") or "")
+        viewer_id = str(message.get("viewerId") or "")
+
+        if message_type == "signal:ready":
+            logging.info("WebRTC signaling ready role=%s deviceId=%s", message.get("role"), message.get("deviceId"))
+            return
+
+        if message_type == "viewer:connected":
+            logging.info("WebRTC viewer connected viewerId=%s", viewer_id)
+            return
+
+        if message_type == "viewer:ready" and viewer_id:
+            logging.info("WebRTC viewer ready viewerId=%s", viewer_id)
+            await self._start_offer(viewer_id)
+            return
+
+        if message_type == "webrtc:answer" and viewer_id:
+            await self._handle_answer(viewer_id, message)
+            return
+
+        if message_type == "webrtc:ice" and viewer_id:
+            await self._handle_remote_ice(viewer_id, message)
+            return
+
+        if message_type == "viewer:disconnected" and viewer_id:
+            logging.info("WebRTC viewer disconnected viewerId=%s", viewer_id)
+            await self._close_peer(viewer_id)
+            return
+
+        logging.debug("Ignoring signaling message: %s", message)
+
+    async def close(self) -> None:
+        await self._close_all_peers()
+        self.source_track.stop()
+
+
+async def async_main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    config = Config.from_env()
+    logging.info(
+        "Pi WebRTC publisher starting deviceId=%s signaling=%s cameraBackend=%s cameraIndex=%s size=%sx%s fps=%.2f",
+        config.device_id,
+        config.signaling_url,
+        config.camera_backend,
+        config.camera_index,
+        config.camera_width,
+        config.camera_height,
+        config.camera_fps,
+    )
+    publisher = WebRtcPublisher(config)
+    try:
+        await publisher.run_forever()
+    except ConnectionClosed:
+        logging.warning("WebRTC signaling connection closed")
+    finally:
+        await publisher.close()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(async_main())
+    except KeyboardInterrupt:
+        pass

--- a/web/app.js
+++ b/web/app.js
@@ -55,6 +55,8 @@ const DRIVE_KEEPALIVE_MS = 200;
 const DRIVE_COMMAND_TTL_MS = 650;
 const BACKEND_RECONNECT_DELAY_MS = 1500;
 const BACKEND_STATE_SYNC_MS = 2000;
+const WEBRTC_RECONNECT_DELAY_MS = 1500;
+const WEBRTC_ICE_GATHERING_TIMEOUT_MS = 5000;
 const CAMERA_NAMES = ["front", "back"];
 const CAMERA_STREAM_FPS_MIN = 1;
 const CAMERA_STREAM_FPS_MAX = 12;
@@ -123,6 +125,17 @@ const backend = {
   deviceId: resolveDeviceId(),
   reconnectTimer: null,
   stateSyncTimer: null
+};
+
+const webrtc = {
+  enabled: urlParams.get("webrtc") !== "0",
+  ws: null,
+  wsUrl: resolveWebRtcSignalingUrl(),
+  viewerId: null,
+  pc: null,
+  remoteStream: null,
+  reconnectTimer: null,
+  offerRequested: false
 };
 
 const driveState = {
@@ -217,6 +230,16 @@ function resolveBackendApiBaseUrl() {
   const host = urlParams.get("backendHost") || window.location.hostname || "127.0.0.1";
   const port = urlParams.get("backendPort") || DEFAULT_BACKEND_PORT;
   return `${protocol}://${host}:${port}`;
+}
+
+function resolveWebRtcSignalingUrl() {
+  const explicitWsUrl = urlParams.get("webrtcWs");
+  if (explicitWsUrl) return explicitWsUrl;
+
+  const protocol = window.location.protocol === "https:" ? "wss" : "ws";
+  const host = urlParams.get("backendHost") || window.location.hostname || "127.0.0.1";
+  const port = urlParams.get("backendPort") || DEFAULT_BACKEND_PORT;
+  return `${protocol}://${host}:${port}/webrtc?role=viewer&deviceId=${encodeURIComponent(resolveDeviceId())}`;
 }
 
 function resolveDeviceId() {
@@ -367,17 +390,19 @@ function isRecordingSessionToggleable(summary) {
 }
 
 function renderCameraStreamControls() {
+  const usingWebRtc = webrtc.enabled;
+
   if (elements.cameraFramerateSlider) {
     elements.cameraFramerateSlider.min = String(cameraControlState.minFps);
     elements.cameraFramerateSlider.max = String(cameraControlState.maxFps);
     elements.cameraFramerateSlider.step = String(CAMERA_STREAM_FPS_STEP);
     elements.cameraFramerateSlider.value = String(clampCameraStreamFps(cameraControlState.desiredFps));
-    elements.cameraFramerateSlider.disabled = !deviceState.connected || cameraControlState.applying;
+    elements.cameraFramerateSlider.disabled = usingWebRtc || !deviceState.connected || cameraControlState.applying;
   }
 
   if (elements.cameraFramerateValue) {
     const value = cameraControlState.applying ? cameraControlState.desiredFps : cameraControlState.actualFps;
-    elements.cameraFramerateValue.textContent = formatCameraStreamFps(value, cameraControlState.applying);
+    elements.cameraFramerateValue.textContent = usingWebRtc ? "WebRTC" : formatCameraStreamFps(value, cameraControlState.applying);
   }
 }
 
@@ -460,6 +485,8 @@ function getCameraStatus(name) {
 
 function setImageSource(element, nextSrc) {
   if (!element) return;
+  if (element instanceof HTMLVideoElement) return;
+
   const currentSrc = element.getAttribute("src") || "";
   if (currentSrc === nextSrc) return;
 
@@ -1374,6 +1401,8 @@ function handleCommandAcceptedMessage(message) {
 }
 
 function handleCameraFrameMessage(message) {
+  if (webrtc.enabled) return;
+
   const frame = message.frame;
   if (!isObject(frame) || frame.deviceId !== backend.deviceId) return;
 
@@ -1421,6 +1450,355 @@ function handleBackendMessage(message) {
   if (message.type === "command:accepted") {
     handleCommandAcceptedMessage(message);
   }
+}
+
+function getWebRtcVideoElements() {
+  return [elements.video, elements.primaryMiniVideo].filter((element) => element instanceof HTMLVideoElement);
+}
+
+function summarizeWebRtcCandidate(candidate) {
+  if (!candidate) return "end-of-candidates";
+  const candidateLine = String(candidate.candidate || "").trim();
+  if (!candidateLine) return "empty-candidate";
+
+  const tokens = candidateLine.replace(/^candidate:/, "").split(/\s+/);
+  const foundation = tokens[0] || "-";
+  const component = tokens[1] || "-";
+  const protocol = tokens[2] || "-";
+  const ip = tokens[4] || "-";
+  const port = tokens[5] || "-";
+  const typeIndex = tokens.indexOf("typ");
+  const candidateType = typeIndex >= 0 ? tokens[typeIndex + 1] || "-" : "-";
+  return `foundation=${foundation} component=${component} protocol=${protocol} address=${ip}:${port} type=${candidateType}`;
+}
+
+function logWebRtcSdp(label, description) {
+  const type = description?.type || "-";
+  const sdp = String(description?.sdp || "");
+  console.info(`${label} SDP type=${type} bytes=${sdp.length}`);
+  if (sdp) {
+    console.info(`${label} SDP body\n${sdp}`);
+  }
+}
+
+function sendWebRtcSignal(payload) {
+  if (!webrtc.ws || webrtc.ws.readyState !== WebSocket.OPEN) return false;
+  webrtc.ws.send(
+    JSON.stringify({
+      ...payload,
+      viewerId: webrtc.viewerId
+    })
+  );
+  return true;
+}
+
+function requestWebRtcOffer() {
+  if (webrtc.offerRequested) return;
+  webrtc.offerRequested = sendWebRtcSignal({ type: "viewer:ready" });
+}
+
+function attachWebRtcStream(stream) {
+  webrtc.remoteStream = stream;
+  state.primaryCameraName = "front";
+
+  for (const video of getWebRtcVideoElements()) {
+    if (video.srcObject !== stream) {
+      video.srcObject = stream;
+    }
+    const playResult = video.play();
+    if (playResult && typeof playResult.catch === "function") {
+      playResult.catch(() => {
+        // Autoplay can be blocked until the user interacts with the page.
+      });
+    }
+  }
+
+  const frontFeed = getCameraState("front");
+  if (frontFeed) {
+    frontFeed.frameSrc = "webrtc";
+    frontFeed.lastFrameAtMs = Date.now();
+    frontFeed.status = {
+      ...(frontFeed.status || {}),
+      name: "front",
+      available: true,
+      streaming: true,
+      backend: "webrtc",
+      lastFrameAt: new Date().toISOString()
+    };
+  }
+
+  const backFeed = getCameraState("back");
+  if (backFeed) {
+    backFeed.frameSrc = "";
+    backFeed.status = {
+      ...(backFeed.status || {}),
+      name: "back",
+      available: false,
+      streaming: false,
+      backend: "disabled",
+      reason: "single-camera-webrtc"
+    };
+  }
+
+  renderCameraFeeds();
+}
+
+function clearWebRtcStream() {
+  for (const video of getWebRtcVideoElements()) {
+    video.srcObject = null;
+  }
+
+  webrtc.remoteStream = null;
+  const frontFeed = getCameraState("front");
+  if (frontFeed?.frameSrc === "webrtc") {
+    frontFeed.frameSrc = "";
+    frontFeed.status = {
+      ...(frontFeed.status || {}),
+      name: "front",
+      streaming: false,
+      backend: "webrtc",
+      reason: "webrtc-disconnected"
+    };
+  }
+
+  renderCameraFeeds();
+}
+
+function closeWebRtcPeerConnection(clearStream = true) {
+  webrtc.offerRequested = false;
+  const pc = webrtc.pc;
+  webrtc.pc = null;
+  if (pc) {
+    pc.ontrack = null;
+    pc.onicecandidate = null;
+    pc.onconnectionstatechange = null;
+    pc.oniceconnectionstatechange = null;
+    pc.onicegatheringstatechange = null;
+    pc.onsignalingstatechange = null;
+    pc.close();
+  }
+
+  if (clearStream) {
+    clearWebRtcStream();
+  }
+}
+
+function scheduleWebRtcReconnect(reason) {
+  if (!webrtc.enabled) return;
+  console.warn(`WebRTC reconnect scheduled: ${reason}`);
+  closeWebRtcPeerConnection(true);
+  window.clearTimeout(webrtc.reconnectTimer);
+  webrtc.reconnectTimer = window.setTimeout(() => {
+    if (webrtc.ws?.readyState === WebSocket.OPEN) {
+      requestWebRtcOffer();
+      return;
+    }
+    connectWebRtcSignaling();
+  }, WEBRTC_RECONNECT_DELAY_MS);
+}
+
+function createWebRtcPeerConnection() {
+  const pc = new RTCPeerConnection({ iceServers: [] });
+
+  pc.ontrack = (event) => {
+    console.info(`WebRTC remote track kind=${event.track.kind} id=${event.track.id}`);
+    const [stream] = event.streams;
+    attachWebRtcStream(stream || new MediaStream([event.track]));
+    event.track.onended = () => {
+      scheduleWebRtcReconnect("remote track ended");
+    };
+  };
+
+  pc.onicecandidate = (event) => {
+    console.info(`WebRTC local ICE ${summarizeWebRtcCandidate(event.candidate)}`);
+    sendWebRtcSignal({
+      type: "webrtc:ice",
+      candidate: event.candidate ? event.candidate.toJSON() : null
+    });
+  };
+
+  pc.onconnectionstatechange = () => {
+    if (webrtc.pc !== pc) return;
+    console.info(`WebRTC peer connection state=${pc.connectionState}`);
+    if (pc.connectionState === "failed") {
+      scheduleWebRtcReconnect("peer connection failed");
+    }
+  };
+
+  pc.oniceconnectionstatechange = () => {
+    if (webrtc.pc !== pc) return;
+    console.info(`WebRTC ICE connection state=${pc.iceConnectionState}`);
+    if (pc.iceConnectionState === "failed") {
+      scheduleWebRtcReconnect("ICE failed");
+    }
+  };
+
+  pc.onicegatheringstatechange = () => {
+    if (webrtc.pc !== pc) return;
+    console.info(`WebRTC ICE gathering state=${pc.iceGatheringState}`);
+  };
+
+  pc.onsignalingstatechange = () => {
+    if (webrtc.pc !== pc) return;
+    console.info(`WebRTC signaling state=${pc.signalingState}`);
+  };
+
+  return pc;
+}
+
+function waitForWebRtcIceGatheringComplete(pc) {
+  if (pc.iceGatheringState === "complete") {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    const timeoutId = window.setTimeout(done, WEBRTC_ICE_GATHERING_TIMEOUT_MS);
+
+    function done() {
+      window.clearTimeout(timeoutId);
+      pc.removeEventListener("icegatheringstatechange", onIceGatheringStateChange);
+      resolve();
+    }
+
+    function onIceGatheringStateChange() {
+      if (pc.iceGatheringState === "complete") {
+        done();
+      }
+    }
+
+    pc.addEventListener("icegatheringstatechange", onIceGatheringStateChange);
+  });
+}
+
+async function handleWebRtcOffer(message) {
+  if (message.deviceId && message.deviceId !== backend.deviceId) return;
+  const sdp = message.sdp;
+  if (!isObject(sdp) || !sdp.sdp || !sdp.type) return;
+
+  closeWebRtcPeerConnection(true);
+  const pc = createWebRtcPeerConnection();
+  webrtc.pc = pc;
+  webrtc.offerRequested = false;
+
+  logWebRtcSdp("Remote offer", sdp);
+  await pc.setRemoteDescription(sdp);
+  const answer = await pc.createAnswer();
+  await pc.setLocalDescription(answer);
+  await waitForWebRtcIceGatheringComplete(pc);
+  logWebRtcSdp("Local answer", pc.localDescription);
+
+  sendWebRtcSignal({
+    type: "webrtc:answer",
+    sdp: {
+      type: pc.localDescription.type,
+      sdp: pc.localDescription.sdp
+    }
+  });
+}
+
+async function handleWebRtcRemoteIce(message) {
+  if (!webrtc.pc) return;
+  if (message.deviceId && message.deviceId !== backend.deviceId) return;
+
+  console.info(`WebRTC remote ICE ${summarizeWebRtcCandidate(message.candidate)}`);
+  await webrtc.pc.addIceCandidate(message.candidate || null);
+}
+
+function handleWebRtcStatus(message) {
+  if (message.deviceId && message.deviceId !== backend.deviceId) return;
+
+  console.info(`WebRTC Pi signaling status=${message.status}`);
+  if (message.status === "online") {
+    requestWebRtcOffer();
+    return;
+  }
+
+  closeWebRtcPeerConnection(true);
+}
+
+function handleWebRtcReady(message) {
+  webrtc.viewerId = message.viewerId || webrtc.viewerId;
+  console.info(`WebRTC signaling ready viewerId=${webrtc.viewerId || "-"} piConnected=${Boolean(message.piConnected)}`);
+  if (message.piConnected) {
+    requestWebRtcOffer();
+  }
+}
+
+async function handleWebRtcSignalMessage(message) {
+  if (!isObject(message)) return;
+
+  if (message.type === "signal:ready") {
+    handleWebRtcReady(message);
+    return;
+  }
+
+  if (message.type === "pi:webrtc-status") {
+    handleWebRtcStatus(message);
+    return;
+  }
+
+  if (message.type === "webrtc:offer") {
+    await handleWebRtcOffer(message);
+    return;
+  }
+
+  if (message.type === "webrtc:ice") {
+    await handleWebRtcRemoteIce(message);
+    return;
+  }
+
+  if (message.type === "webrtc:error") {
+    console.warn(`WebRTC publisher error: ${message.error || "unknown error"}`);
+    scheduleWebRtcReconnect("publisher error");
+  }
+}
+
+function connectWebRtcSignaling() {
+  if (!webrtc.enabled) return;
+
+  const readyState = webrtc.ws?.readyState;
+  if (readyState === WebSocket.OPEN || readyState === WebSocket.CONNECTING) {
+    return;
+  }
+
+  if (!window.RTCPeerConnection) {
+    console.warn("WebRTC is not available in this browser.");
+    return;
+  }
+
+  const ws = new WebSocket(webrtc.wsUrl);
+  webrtc.ws = ws;
+
+  ws.addEventListener("open", () => {
+    console.info("Connected to WebRTC signaling socket.");
+  });
+
+  ws.addEventListener("close", () => {
+    if (webrtc.ws !== ws) return;
+
+    webrtc.ws = null;
+    webrtc.viewerId = null;
+    webrtc.offerRequested = false;
+    closeWebRtcPeerConnection(true);
+    window.clearTimeout(webrtc.reconnectTimer);
+    webrtc.reconnectTimer = window.setTimeout(connectWebRtcSignaling, WEBRTC_RECONNECT_DELAY_MS);
+  });
+
+  ws.addEventListener("message", (event) => {
+    try {
+      const message = JSON.parse(String(event.data || "{}"));
+      void handleWebRtcSignalMessage(message).catch((error) => {
+        console.warn(`WebRTC signaling error: ${error instanceof Error ? error.message : String(error)}`);
+        scheduleWebRtcReconnect("signaling handler error");
+      });
+    } catch (error) {
+      console.warn(`Invalid WebRTC signaling payload: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  });
+
+  ws.addEventListener("error", () => {
+    ws.close();
+  });
 }
 
 async function syncBackendState() {
@@ -2132,6 +2510,10 @@ function setupEvents() {
   });
   window.addEventListener("beforeunload", () => {
     stopAllDrive();
+    closeWebRtcPeerConnection(false);
+    if (webrtc.ws) {
+      webrtc.ws.close();
+    }
   });
 }
 
@@ -2150,6 +2532,7 @@ function boot() {
   }
 
   connectBackendSocket();
+  connectWebRtcSignaling();
   renderCameraFeeds();
 }
 

--- a/web/index.html
+++ b/web/index.html
@@ -4,11 +4,11 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Camera Control Overlay</title>
-  <link rel="stylesheet" href="./styles.css?v=20260410-2" />
+  <link rel="stylesheet" href="./styles.css?v=20260413-1" />
 </head>
 <body>
   <main id="app-root" class="app">
-    <img id="camera-feed" class="camera-feed" alt="Primary Raspberry Pi camera feed" />
+    <video id="camera-feed" class="camera-feed" autoplay playsinline muted aria-label="Primary Raspberry Pi camera feed"></video>
     <div class="overlay">
       <div class="lidar-side">
         <div class="lidar-map" aria-label="Live LiDAR map">
@@ -43,7 +43,7 @@
         <div class="camera-rail" aria-label="Front and back camera previews">
           <div id="primary-mini-feed-shell" class="primary-mini-feed-shell camera-panel" aria-label="Primary camera preview">
             <span id="primary-camera-label" class="camera-panel-label">Front</span>
-            <img id="primary-mini-feed" class="secondary-feed" alt="Primary robot camera preview" />
+            <video id="primary-mini-feed" class="secondary-feed" autoplay playsinline muted aria-label="Primary robot camera preview"></video>
           </div>
 
           <div id="secondary-feed-shell" class="secondary-feed-shell camera-panel" aria-label="Secondary camera feed">
@@ -199,6 +199,6 @@
     </div>
   </main>
 
-  <script src="./app.js?v=20260410-1"></script>
+  <script src="./app.js?v=20260413-1"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add a separate `/webrtc` WebSocket signaling lane on the backend while keeping existing `/ws` controls and telemetry intact.
- Add a Pi-side aiortc publisher for one camera stream, plus a camera track module for rpicam/libcamera with OpenCV fallback.
- Update the browser client to negotiate WebRTC video, attach the remote stream to the existing camera view, log SDP/ICE/state, and reconnect on failures.
- Document dependencies, file structure, run steps, and the next plan for controls, second camera, TURN, and switching.

## Validation
- npm --prefix backend run check
- node --check web/app.js
- python3 -m py_compile pi/gateway.py pi/webrtc_camera.py pi/webrtc_publisher.py
- git diff --cached --check
- WebRTC signaling smoke test on local backend port 3199

## Notes
- Live Pi camera media was not tested on this Mac because it does not have the Raspberry Pi camera stack attached.