### PR TITLE
[codex] Tune WebRTC video for low latency

### DIFF
--- a/docs/webrtc-video-first-pass.md
+++ b/docs/webrtc-video-first-pass.md
@@ -27,7 +27,7 @@ Raspberry Pi
   pi/webrtc_publisher.py
   - connects to /webrtc as role=pi
   - creates one RTCPeerConnection per browser viewer
-  - publishes one camera track from pi/webrtc_camera.py
+  - publishes one latest-frame-only camera track from pi/webrtc_camera.py
 ```
 
 The first negotiation flow is:
@@ -37,8 +37,9 @@ The first negotiation flow is:
 3. Browser sends `viewer:ready`.
 4. Pi creates an offer with one video track and sends `webrtc:offer`.
 5. Browser creates an answer and sends `webrtc:answer`.
-6. Browser and Pi log SDP, ICE candidates, ICE state, signaling state, and peer
-   connection state.
+6. Browser and Pi log SDP, ICE candidates, ICE state, signaling state, peer
+   connection state, capture timing, outbound stats, and browser receive/render
+   timing.
 
 ## Dependency List
 
@@ -147,11 +148,19 @@ http://<pc-ip>:8080?backendHost=<pc-ip>&deviceId=pi-01
 ```bash
 WEBRTC_CAMERA_INDEX=0
 WEBRTC_CAMERA_BACKEND=auto     # auto | rpicam | opencv
-WEBRTC_CAMERA_WIDTH=960
-WEBRTC_CAMERA_HEIGHT=720
-WEBRTC_CAMERA_FPS=15
+WEBRTC_CAMERA_WIDTH=640
+WEBRTC_CAMERA_HEIGHT=480
+WEBRTC_CAMERA_FPS=20
 WEBRTC_CAMERA_JPEG_QUALITY=70
+WEBRTC_VIDEO_CODEC=H264        # H264 preferred, VP8 fallback if unavailable
+WEBRTC_STATS_INTERVAL_SEC=2
 WEBRTC_LOG_SDP=1
+```
+
+For a sharper but still conservative profile, try:
+
+```bash
+WEBRTC_CAMERA_WIDTH=1280 WEBRTC_CAMERA_HEIGHT=720 WEBRTC_CAMERA_FPS=15
 ```
 
 Browser query-string overrides:
@@ -176,6 +185,10 @@ Pi publisher logs include:
 - local ICE candidates embedded in SDP
 - remote ICE candidates from the browser
 - peer connection, ICE connection, ICE gathering, and signaling state
+- camera capture FPS, dropped old frames, JPEG decode time, and
+  capture-to-encode-input handoff time
+- outbound WebRTC frame rate, network send bitrate, packet rate, and encode time
+  per frame when aiortc exposes it
 
 Browser logs include:
 
@@ -184,6 +197,49 @@ Browser logs include:
 - local answer SDP
 - local and remote ICE candidates
 - peer connection, ICE connection, ICE gathering, and signaling state
+- receive frame rate, network receive bitrate, decode time, jitter-buffer delay,
+  dropped frames, and packet loss
+- render frame rate, receive-to-render delay, capture-to-render delay when the
+  browser exposes it, render queue delay, and processing time
+
+## Low-Latency Defaults
+
+- WebRTC camera defaults to `640x480` at `20 fps`.
+- The Pi camera reader drains camera stdout continuously and keeps only the most
+  recent frame.
+- The aiortc `MediaRelay` subscriber is unbuffered, so slow viewers do not build
+  per-viewer frame queues.
+- The browser requests `playoutDelayHint=0` when supported.
+- H.264 is preferred in codec negotiation. aiortc can only use hardware H.264 if
+  the local encoder stack exposes it; otherwise it falls back to the available
+  H.264 or VP8 implementation.
+
+## Tuning Order
+
+Less delay:
+
+1. Keep `WEBRTC_CAMERA_WIDTH=640`, `WEBRTC_CAMERA_HEIGHT=480`, and
+   `WEBRTC_CAMERA_FPS=20`.
+2. Watch `droppedOldFrames`, `captureToEncodeInputMsAvg`, `networkSendKbps`,
+   browser `jitterBufferMs`, and `receiveToRenderMs`.
+3. If `captureToEncodeInputMsAvg` or `encodeMsPerFrame` grows, lower FPS before
+   raising resolution.
+4. If browser `jitterBufferMs` grows, lower resolution or move to a cleaner
+   network path before increasing sharpness.
+
+Better sharpness:
+
+1. Try `WEBRTC_CAMERA_WIDTH=1280 WEBRTC_CAMERA_HEIGHT=720 WEBRTC_CAMERA_FPS=15`.
+2. If delay stays acceptable, try `WEBRTC_CAMERA_FPS=20`.
+3. Keep `WEBRTC_VIDEO_CODEC=H264` unless a browser/device behaves worse with it.
+
+More stability:
+
+1. Use `640x480` at `15 fps`.
+2. Keep H.264 preferred, but try `WEBRTC_VIDEO_CODEC=VP8` if H.264 negotiation is
+   unstable on a specific browser.
+3. If ICE is unstable off-LAN, add TURN next; this pass intentionally does not
+   add TURN yet.
 
 ## Current Limits
 

--- a/pi/README.md
+++ b/pi/README.md
@@ -216,8 +216,10 @@ The ESP firmware interprets ANSI arrow escape sequences, so this script sends
 - `PI_CAMERA_JPEG_ENABLED` default: `1` (set `0` when `pi/webrtc_publisher.py` owns the camera)
 - `WEBRTC_CAMERA_INDEX` default: `CAMERA_FRONT_INDEX` / `0`
 - `WEBRTC_CAMERA_BACKEND` default: `auto`, supported values: `auto`, `rpicam`, `opencv`
-- `WEBRTC_CAMERA_WIDTH` / `WEBRTC_CAMERA_HEIGHT` default to `CAMERA_FRAME_WIDTH` / `CAMERA_FRAME_HEIGHT`
-- `WEBRTC_CAMERA_FPS` default: `15`
+- `WEBRTC_CAMERA_WIDTH` / `WEBRTC_CAMERA_HEIGHT` default to `640` / `480`
+- `WEBRTC_CAMERA_FPS` default: `20`
+- `WEBRTC_VIDEO_CODEC` default: `H264` (prefers H.264 in WebRTC negotiation)
+- `WEBRTC_STATS_INTERVAL_SEC` default: `2`
 - `WEBRTC_LOG_SDP` default: `1`
 - `LIDAR_ENABLED` default: `1` (set `0` to disable streaming)
 - `LIDAR_SERIAL_PORT` default: `/dev/ttyUSB1` when `PI_MOTOR_DRIVER=esp`, otherwise `/dev/ttyUSB0`

--- a/pi/webrtc_camera.py
+++ b/pi/webrtc_camera.py
@@ -41,6 +41,70 @@ class CameraTrackConfig:
     height: int
     fps: float
     jpeg_quality: int
+    stats_interval_sec: float = 2.0
+
+
+class CameraTimingLogger:
+    def __init__(self, source: str, log_interval_sec: float) -> None:
+        self.source = source
+        self.log_interval_sec = max(0.5, log_interval_sec)
+        self.capture_count = 0
+        self.return_count = 0
+        self.drop_count = 0
+        self.decode_time_ms_total = 0.0
+        self.capture_to_handoff_ms_total = 0.0
+        self._last_log_at = time.monotonic()
+        self._last_capture_count = 0
+        self._last_return_count = 0
+        self._last_drop_count = 0
+        self._last_decode_time_ms_total = 0.0
+        self._last_capture_to_handoff_ms_total = 0.0
+
+    def record_capture(self, frame_count: int = 1, dropped_count: int = 0) -> None:
+        self.capture_count += max(0, frame_count)
+        self.drop_count += max(0, dropped_count)
+
+    def record_handoff(self, *, decode_ms: float, capture_to_handoff_ms: float) -> None:
+        self.return_count += 1
+        self.decode_time_ms_total += max(0.0, decode_ms)
+        self.capture_to_handoff_ms_total += max(0.0, capture_to_handoff_ms)
+
+    def maybe_log(self, force: bool = False) -> None:
+        now = time.monotonic()
+        elapsed_sec = now - self._last_log_at
+        if not force and elapsed_sec < self.log_interval_sec:
+            return
+
+        capture_delta = self.capture_count - self._last_capture_count
+        return_delta = self.return_count - self._last_return_count
+        drop_delta = self.drop_count - self._last_drop_count
+        decode_delta = self.decode_time_ms_total - self._last_decode_time_ms_total
+        handoff_delta = self.capture_to_handoff_ms_total - self._last_capture_to_handoff_ms_total
+
+        capture_fps = capture_delta / elapsed_sec if elapsed_sec > 0 else 0.0
+        handoff_fps = return_delta / elapsed_sec if elapsed_sec > 0 else 0.0
+        decode_ms_avg = decode_delta / return_delta if return_delta > 0 else 0.0
+        capture_to_handoff_ms_avg = handoff_delta / return_delta if return_delta > 0 else 0.0
+
+        logging.info(
+            (
+                "WebRTC camera timing source=%s captureFps=%.1f encodeInputFps=%.1f "
+                "droppedOldFrames=%s decodeMsAvg=%.1f captureToEncodeInputMsAvg=%.1f"
+            ),
+            self.source,
+            capture_fps,
+            handoff_fps,
+            drop_delta,
+            decode_ms_avg,
+            capture_to_handoff_ms_avg,
+        )
+
+        self._last_log_at = now
+        self._last_capture_count = self.capture_count
+        self._last_return_count = self.return_count
+        self._last_drop_count = self.drop_count
+        self._last_decode_time_ms_total = self.decode_time_ms_total
+        self._last_capture_to_handoff_ms_total = self.capture_to_handoff_ms_total
 
 
 def clamp_int(value: int, minimum: int, maximum: int) -> int:
@@ -85,6 +149,14 @@ class RpicamMjpegCameraTrack(VideoStreamTrack):
         self.command_name = command_name
         self._buffer = bytearray()
         self._process: Optional[asyncio.subprocess.Process] = None
+        self._reader_task: Optional[asyncio.Task[None]] = None
+        self._latest_jpeg: Optional[tuple[bytes, float]] = None
+        self._latest_event = asyncio.Event()
+        self._has_unconsumed_frame = False
+        self._timing_logger = CameraTimingLogger(
+            source=f"{command_name}:mjpeg",
+            log_interval_sec=config.stats_interval_sec,
+        )
         self._started_once = False
 
     def _build_command(self) -> List[str]:
@@ -143,25 +215,26 @@ class RpicamMjpegCameraTrack(VideoStreamTrack):
             return
 
     @staticmethod
-    def _extract_jpeg(buffer: bytearray) -> Optional[bytes]:
+    def _extract_jpegs(buffer: bytearray) -> List[bytes]:
+        frames: List[bytes] = []
         while True:
             start_index = buffer.find(JPEG_SOI)
             if start_index < 0:
                 if len(buffer) > 1:
                     del buffer[:-1]
-                return None
+                return frames
 
             if start_index > 0:
                 del buffer[:start_index]
 
             end_index = buffer.find(JPEG_EOI, 2)
             if end_index < 0:
-                return None
+                return frames
 
             frame = bytes(buffer[: end_index + 2])
             del buffer[: end_index + 2]
             if len(frame) >= 1024:
-                return frame
+                frames.append(frame)
 
     @staticmethod
     def _decode_jpeg(jpeg_bytes: bytes) -> VideoFrame:
@@ -171,7 +244,7 @@ class RpicamMjpegCameraTrack(VideoStreamTrack):
             image = image.convert("RGB")
         return VideoFrame.from_image(image)
 
-    async def _read_jpeg(self) -> bytes:
+    async def _reader_loop(self) -> None:
         while self.readyState == "live":
             process = await self._ensure_process()
             assert process.stdout is not None
@@ -184,20 +257,67 @@ class RpicamMjpegCameraTrack(VideoStreamTrack):
                 continue
 
             self._buffer.extend(chunk)
-            frame = self._extract_jpeg(self._buffer)
-            if frame:
-                return frame
+            frames = self._extract_jpegs(self._buffer)
+            if not frames:
+                continue
+
+            dropped_count = max(0, len(frames) - 1)
+            if self._has_unconsumed_frame:
+                dropped_count += 1
+
+            self._latest_jpeg = (frames[-1], time.perf_counter())
+            self._has_unconsumed_frame = True
+            self._latest_event.set()
+            self._timing_logger.record_capture(frame_count=len(frames), dropped_count=dropped_count)
+            self._timing_logger.maybe_log()
+
+    def _ensure_reader_task(self) -> None:
+        if self._reader_task is not None and not self._reader_task.done():
+            return
+        self._reader_task = asyncio.create_task(self._reader_loop(), name=f"webrtc-camera-reader-{self.config.camera_index}")
+        self._reader_task.add_done_callback(self._log_reader_task_result)
+
+    @staticmethod
+    def _log_reader_task_result(task: asyncio.Task[None]) -> None:
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc:
+            logging.warning("WebRTC camera reader stopped: %s", exc)
+
+    async def _read_latest_jpeg(self) -> tuple[bytes, float]:
+        self._ensure_reader_task()
+        while self.readyState == "live":
+            try:
+                await asyncio.wait_for(self._latest_event.wait(), timeout=1.0)
+            except asyncio.TimeoutError:
+                self._ensure_reader_task()
+                continue
+
+            latest = self._latest_jpeg
+            self._latest_event.clear()
+            self._has_unconsumed_frame = False
+            if latest is not None:
+                return latest
 
         raise MediaStreamError
 
     async def recv(self) -> VideoFrame:
         while self.readyState == "live":
-            jpeg_bytes = await self._read_jpeg()
+            jpeg_bytes, captured_at = await self._read_latest_jpeg()
+            decode_started_at = time.perf_counter()
             try:
                 frame = self._decode_jpeg(jpeg_bytes)
             except Exception as exc:
                 logging.warning("WebRTC camera JPEG decode failed: %s", exc)
                 continue
+
+            now = time.perf_counter()
+            self._timing_logger.record_handoff(
+                decode_ms=(now - decode_started_at) * 1000.0,
+                capture_to_handoff_ms=(now - captured_at) * 1000.0,
+            )
+            self._timing_logger.maybe_log()
 
             pts, time_base = await self.next_timestamp()
             frame.pts = pts
@@ -207,6 +327,9 @@ class RpicamMjpegCameraTrack(VideoStreamTrack):
         raise MediaStreamError
 
     def stop(self) -> None:
+        if self._reader_task is not None:
+            self._reader_task.cancel()
+            self._reader_task = None
         self._terminate_process()
         super().stop()
 
@@ -219,6 +342,10 @@ class OpenCvCameraTrack(VideoStreamTrack):
         self.config = config
         self._capture: Optional[object] = None
         self._last_frame_monotonic = 0.0
+        self._timing_logger = CameraTimingLogger(
+            source="opencv",
+            log_interval_sec=config.stats_interval_sec,
+        )
 
     def _open_capture(self) -> object:
         if cv2 is None:
@@ -232,6 +359,7 @@ class OpenCvCameraTrack(VideoStreamTrack):
         capture.set(cv2.CAP_PROP_FRAME_WIDTH, float(max(160, self.config.width)))
         capture.set(cv2.CAP_PROP_FRAME_HEIGHT, float(max(120, self.config.height)))
         capture.set(cv2.CAP_PROP_FPS, float(clamp_float(self.config.fps, 1.0, 60.0)))
+        capture.set(cv2.CAP_PROP_BUFFERSIZE, 1)
         logging.info("WebRTC camera starting via OpenCV index=%s", self.config.camera_index)
         return capture
 
@@ -250,11 +378,22 @@ class OpenCvCameraTrack(VideoStreamTrack):
 
     def _read_frame(self) -> VideoFrame:
         capture = self._ensure_capture()
+        captured_at = time.perf_counter()
         ok, image = capture.read()
         if not ok or image is None:
             self._release_capture()
             raise RuntimeError("OpenCV camera read failed")
-        return VideoFrame.from_ndarray(image, format="bgr24")
+
+        decode_started_at = time.perf_counter()
+        frame = VideoFrame.from_ndarray(image, format="bgr24")
+        now = time.perf_counter()
+        self._timing_logger.record_capture()
+        self._timing_logger.record_handoff(
+            decode_ms=(now - decode_started_at) * 1000.0,
+            capture_to_handoff_ms=(now - captured_at) * 1000.0,
+        )
+        self._timing_logger.maybe_log()
+        return frame
 
     async def _pace(self) -> None:
         interval_sec = 1.0 / clamp_float(self.config.fps, 1.0, 60.0)

--- a/pi/webrtc_publisher.py
+++ b/pi/webrtc_publisher.py
@@ -19,7 +19,7 @@ from urllib.parse import urlencode
 import websockets
 from websockets.exceptions import ConnectionClosed
 
-from aiortc import RTCIceCandidate, RTCPeerConnection, RTCSessionDescription
+from aiortc import RTCIceCandidate, RTCPeerConnection, RTCRtpSender, RTCSessionDescription
 from aiortc.contrib.media import MediaRelay
 
 from webrtc_camera import CameraTrackConfig, create_camera_track
@@ -72,6 +72,8 @@ class Config:
     camera_height: int
     camera_fps: float
     camera_jpeg_quality: int
+    video_codec: str
+    stats_interval_sec: float
 
     @property
     def signaling_url(self) -> str:
@@ -84,8 +86,6 @@ class Config:
     @staticmethod
     def from_env() -> "Config":
         backend_ws_base = os.getenv("BACKEND_WS_BASE", "ws://127.0.0.1:3000")
-        frame_width = env_int("CAMERA_FRAME_WIDTH", 960)
-        frame_height = env_int("CAMERA_FRAME_HEIGHT", 720)
         return Config(
             signaling_ws_base=os.getenv("WEBRTC_SIGNALING_WS_BASE", backend_ws_base),
             device_id=os.getenv("PI_DEVICE_ID", "pi-01"),
@@ -94,10 +94,12 @@ class Config:
             log_sdp=env_flag("WEBRTC_LOG_SDP", default=True),
             camera_backend=os.getenv("WEBRTC_CAMERA_BACKEND", "auto"),
             camera_index=env_int_any(("WEBRTC_CAMERA_INDEX", "CAMERA_FRONT_INDEX", "CAMERA_LEFT_INDEX"), 0),
-            camera_width=env_int("WEBRTC_CAMERA_WIDTH", frame_width),
-            camera_height=env_int("WEBRTC_CAMERA_HEIGHT", frame_height),
-            camera_fps=env_float("WEBRTC_CAMERA_FPS", 15.0),
+            camera_width=env_int("WEBRTC_CAMERA_WIDTH", 640),
+            camera_height=env_int("WEBRTC_CAMERA_HEIGHT", 480),
+            camera_fps=env_float("WEBRTC_CAMERA_FPS", 20.0),
             camera_jpeg_quality=env_int("WEBRTC_CAMERA_JPEG_QUALITY", env_int("CAMERA_JPEG_QUALITY", 70)),
+            video_codec=os.getenv("WEBRTC_VIDEO_CODEC", "H264"),
+            stats_interval_sec=env_float("WEBRTC_STATS_INTERVAL_SEC", 2.0),
         )
 
     def camera_track_config(self) -> CameraTrackConfig:
@@ -108,6 +110,7 @@ class Config:
             height=self.camera_height,
             fps=self.camera_fps,
             jpeg_quality=self.camera_jpeg_quality,
+            stats_interval_sec=self.stats_interval_sec,
         )
 
 
@@ -174,12 +177,27 @@ def parse_browser_candidate(payload: Optional[JsonDict]) -> Optional[RTCIceCandi
     )
 
 
+def stat_value(stat: Any, name: str, default: Any = None) -> Any:
+    if isinstance(stat, dict):
+        return stat.get(name, default)
+    return getattr(stat, name, default)
+
+
+def describe_codec(codec: Any) -> str:
+    mime_type = getattr(codec, "mimeType", "unknown")
+    clock_rate = getattr(codec, "clockRate", None)
+    parameters = getattr(codec, "parameters", None) or {}
+    parameter_suffix = f" parameters={parameters}" if parameters else ""
+    return f"{mime_type}/{clock_rate or '-'}{parameter_suffix}"
+
+
 class WebRtcPublisher:
     def __init__(self, config: Config) -> None:
         self.config = config
         self.relay = MediaRelay()
         self.source_track = create_camera_track(config.camera_track_config())
         self.peers: Dict[str, RTCPeerConnection] = {}
+        self.stats_tasks: Dict[str, asyncio.Task[None]] = {}
         self.ws: Optional[Any] = None
 
     async def run_forever(self) -> None:
@@ -246,11 +264,135 @@ class WebRtcPublisher:
         except asyncio.TimeoutError:
             logging.warning("ICE gathering timed out viewerId=%s state=%s", viewer_id, pc.iceGatheringState)
 
+    def _prefer_video_codec(self, pc: RTCPeerConnection, sender: RTCRtpSender, viewer_id: str) -> None:
+        requested_codec = self.config.video_codec.strip().lower().replace("h.264", "h264")
+        if not requested_codec or requested_codec == "auto":
+            logging.info("Video codec preference viewerId=%s requested=auto", viewer_id)
+            return
+
+        transceiver = next((item for item in pc.getTransceivers() if item.sender == sender), None)
+        if transceiver is None:
+            logging.warning("Video codec preference skipped viewerId=%s reason=missing_transceiver", viewer_id)
+            return
+
+        capabilities = RTCRtpSender.getCapabilities("video")
+        codec_prefix = f"video/{requested_codec}"
+        preferred_codecs = [
+            codec for codec in capabilities.codecs if getattr(codec, "mimeType", "").lower() == codec_prefix
+        ]
+        fallback_codecs = [
+            codec for codec in capabilities.codecs if getattr(codec, "mimeType", "").lower() != codec_prefix
+        ]
+
+        if not preferred_codecs:
+            logging.warning(
+                "Video codec preference unavailable viewerId=%s requested=%s available=%s",
+                viewer_id,
+                self.config.video_codec,
+                ", ".join(describe_codec(codec) for codec in capabilities.codecs),
+            )
+            return
+
+        transceiver.setCodecPreferences([*preferred_codecs, *fallback_codecs])
+        logging.info(
+            "Video codec preference viewerId=%s requested=%s preferred=%s note=%s",
+            viewer_id,
+            self.config.video_codec,
+            ", ".join(describe_codec(codec) for codec in preferred_codecs),
+            "H264 can use hardware only if the local aiortc/PyAV encoder stack exposes it",
+        )
+
+    async def _stats_loop(self, viewer_id: str, sender: RTCRtpSender) -> None:
+        last_logged_at = asyncio.get_running_loop().time()
+        last_frames_encoded: Optional[int] = None
+        last_total_encode_time: Optional[float] = None
+        last_bytes_sent: Optional[int] = None
+        last_packets_sent: Optional[int] = None
+
+        while viewer_id in self.peers:
+            await asyncio.sleep(max(0.5, self.config.stats_interval_sec))
+            now = asyncio.get_running_loop().time()
+            elapsed_sec = max(0.001, now - last_logged_at)
+            last_logged_at = now
+
+            try:
+                report = await sender.getStats()
+            except Exception as exc:
+                logging.warning("WebRTC outbound stats unavailable viewerId=%s error=%s", viewer_id, exc)
+                continue
+
+            outbound_stats = None
+            for stat in report.values():
+                if stat_value(stat, "type") != "outbound-rtp":
+                    continue
+                kind = stat_value(stat, "kind") or stat_value(stat, "mediaType")
+                if kind in {None, "video"}:
+                    outbound_stats = stat
+                    break
+
+            if outbound_stats is None:
+                logging.info("WebRTC outbound stats viewerId=%s unavailable=no_outbound_video_stat", viewer_id)
+                continue
+
+            frames_encoded = stat_value(outbound_stats, "framesEncoded")
+            total_encode_time = stat_value(outbound_stats, "totalEncodeTime")
+            bytes_sent = stat_value(outbound_stats, "bytesSent")
+            packets_sent = stat_value(outbound_stats, "packetsSent")
+
+            outbound_fps = None
+            encode_ms_per_frame = None
+            if isinstance(frames_encoded, int) and last_frames_encoded is not None:
+                frame_delta = frames_encoded - last_frames_encoded
+                outbound_fps = frame_delta / elapsed_sec
+                if (
+                    frame_delta > 0
+                    and isinstance(total_encode_time, (float, int))
+                    and isinstance(last_total_encode_time, (float, int))
+                ):
+                    encode_ms_per_frame = ((total_encode_time - last_total_encode_time) * 1000.0) / frame_delta
+
+            bitrate_kbps = None
+            if isinstance(bytes_sent, int) and last_bytes_sent is not None:
+                bitrate_kbps = ((bytes_sent - last_bytes_sent) * 8.0) / elapsed_sec / 1000.0
+
+            packet_rate = None
+            if isinstance(packets_sent, int) and last_packets_sent is not None:
+                packet_rate = (packets_sent - last_packets_sent) / elapsed_sec
+
+            logging.info(
+                (
+                    "WebRTC outbound stats viewerId=%s outboundFps=%s encodeMsPerFrame=%s "
+                    "networkSendKbps=%s packetRate=%s framesEncoded=%s packetsSent=%s bytesSent=%s"
+                ),
+                viewer_id,
+                f"{outbound_fps:.1f}" if outbound_fps is not None else "unavailable",
+                f"{encode_ms_per_frame:.1f}" if encode_ms_per_frame is not None else "unavailable",
+                f"{bitrate_kbps:.0f}" if bitrate_kbps is not None else "unavailable",
+                f"{packet_rate:.1f}" if packet_rate is not None else "unavailable",
+                frames_encoded if frames_encoded is not None else "unavailable",
+                packets_sent if packets_sent is not None else "unavailable",
+                bytes_sent if bytes_sent is not None else "unavailable",
+            )
+
+            if isinstance(frames_encoded, int):
+                last_frames_encoded = frames_encoded
+            if isinstance(total_encode_time, (float, int)):
+                last_total_encode_time = float(total_encode_time)
+            if isinstance(bytes_sent, int):
+                last_bytes_sent = bytes_sent
+            if isinstance(packets_sent, int):
+                last_packets_sent = packets_sent
+
     async def _create_peer(self, viewer_id: str) -> RTCPeerConnection:
         await self._close_peer(viewer_id)
         pc = RTCPeerConnection()
         self.peers[viewer_id] = pc
-        pc.addTrack(self.relay.subscribe(self.source_track))
+        sender = pc.addTrack(self.relay.subscribe(self.source_track, buffered=False))
+        self._prefer_video_codec(pc, sender, viewer_id)
+        self.stats_tasks[viewer_id] = asyncio.create_task(
+            self._stats_loop(viewer_id, sender),
+            name=f"webrtc-outbound-stats-{viewer_id}",
+        )
 
         @pc.on("connectionstatechange")
         async def on_connection_state_change() -> None:
@@ -321,6 +463,10 @@ class WebRtcPublisher:
         await pc.addIceCandidate(candidate)
 
     async def _close_peer(self, viewer_id: str) -> None:
+        stats_task = self.stats_tasks.pop(viewer_id, None)
+        if stats_task is not None:
+            stats_task.cancel()
+
         pc = self.peers.pop(viewer_id, None)
         if pc is None:
             return
@@ -372,7 +518,10 @@ async def async_main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
     config = Config.from_env()
     logging.info(
-        "Pi WebRTC publisher starting deviceId=%s signaling=%s cameraBackend=%s cameraIndex=%s size=%sx%s fps=%.2f",
+        (
+            "Pi WebRTC publisher starting deviceId=%s signaling=%s cameraBackend=%s cameraIndex=%s "
+            "size=%sx%s fps=%.2f codec=%s statsIntervalSec=%.1f"
+        ),
         config.device_id,
         config.signaling_url,
         config.camera_backend,
@@ -380,6 +529,8 @@ async def async_main() -> None:
         config.camera_width,
         config.camera_height,
         config.camera_fps,
+        config.video_codec,
+        config.stats_interval_sec,
     )
     publisher = WebRtcPublisher(config)
     try:

--- a/web/app.js
+++ b/web/app.js
@@ -57,6 +57,7 @@ const BACKEND_RECONNECT_DELAY_MS = 1500;
 const BACKEND_STATE_SYNC_MS = 2000;
 const WEBRTC_RECONNECT_DELAY_MS = 1500;
 const WEBRTC_ICE_GATHERING_TIMEOUT_MS = 5000;
+const WEBRTC_STATS_INTERVAL_MS = 2000;
 const CAMERA_NAMES = ["front", "back"];
 const CAMERA_STREAM_FPS_MIN = 1;
 const CAMERA_STREAM_FPS_MAX = 12;
@@ -135,7 +136,10 @@ const webrtc = {
   pc: null,
   remoteStream: null,
   reconnectTimer: null,
-  offerRequested: false
+  offerRequested: false,
+  statsTimer: null,
+  inboundStats: null,
+  renderStats: null
 };
 
 const driveState = {
@@ -1497,6 +1501,148 @@ function requestWebRtcOffer() {
   webrtc.offerRequested = sendWebRtcSignal({ type: "viewer:ready" });
 }
 
+function formatNullableNumber(value, digits = 1) {
+  return Number.isFinite(value) ? value.toFixed(digits) : "unavailable";
+}
+
+function stopWebRtcStats() {
+  if (webrtc.statsTimer) {
+    window.clearInterval(webrtc.statsTimer);
+    webrtc.statsTimer = null;
+  }
+  if (
+    webrtc.renderStats?.callbackId &&
+    elements.video &&
+    typeof elements.video.cancelVideoFrameCallback === "function"
+  ) {
+    elements.video.cancelVideoFrameCallback(webrtc.renderStats.callbackId);
+  }
+  webrtc.inboundStats = null;
+  webrtc.renderStats = null;
+}
+
+function startWebRtcPeerStats(pc) {
+  if (webrtc.statsTimer) {
+    window.clearInterval(webrtc.statsTimer);
+  }
+
+  webrtc.inboundStats = null;
+  webrtc.statsTimer = window.setInterval(async () => {
+    if (webrtc.pc !== pc) return;
+
+    try {
+      const report = await pc.getStats();
+      let inbound = null;
+      report.forEach((stat) => {
+        if (stat.type === "inbound-rtp" && (!stat.kind || stat.kind === "video")) {
+          inbound = stat;
+        }
+      });
+      if (!inbound) return;
+
+      const now = performance.now();
+      const previous = webrtc.inboundStats;
+      const elapsedSec = previous ? Math.max(0.001, (now - previous.loggedAtMs) / 1000) : 0;
+
+      const framesDecodedDelta = previous ? (inbound.framesDecoded || 0) - (previous.framesDecoded || 0) : 0;
+      const bytesReceivedDelta = previous ? (inbound.bytesReceived || 0) - (previous.bytesReceived || 0) : 0;
+      const totalDecodeTimeDelta = previous ? (inbound.totalDecodeTime || 0) - (previous.totalDecodeTime || 0) : 0;
+      const jitterBufferDelayDelta = previous ? (inbound.jitterBufferDelay || 0) - (previous.jitterBufferDelay || 0) : 0;
+      const jitterBufferFramesDelta = previous
+        ? (inbound.jitterBufferEmittedCount || 0) - (previous.jitterBufferEmittedCount || 0)
+        : 0;
+
+      const receiveFps = previous ? framesDecodedDelta / elapsedSec : null;
+      const receiveKbps = previous ? (bytesReceivedDelta * 8) / elapsedSec / 1000 : null;
+      const decodeMsPerFrame = framesDecodedDelta > 0 ? (totalDecodeTimeDelta * 1000) / framesDecodedDelta : null;
+      const jitterBufferMs =
+        jitterBufferFramesDelta > 0 ? (jitterBufferDelayDelta * 1000) / jitterBufferFramesDelta : null;
+
+      console.info(
+        [
+          "WebRTC browser receive stats",
+          `receiveFps=${formatNullableNumber(receiveFps)}`,
+          `networkReceiveKbps=${formatNullableNumber(receiveKbps, 0)}`,
+          `decodeMsPerFrame=${formatNullableNumber(decodeMsPerFrame)}`,
+          `jitterBufferMs=${formatNullableNumber(jitterBufferMs)}`,
+          `framesDropped=${inbound.framesDropped ?? "unavailable"}`,
+          `packetsLost=${inbound.packetsLost ?? "unavailable"}`
+        ].join(" ")
+      );
+
+      webrtc.inboundStats = {
+        loggedAtMs: now,
+        framesDecoded: inbound.framesDecoded || 0,
+        bytesReceived: inbound.bytesReceived || 0,
+        totalDecodeTime: inbound.totalDecodeTime || 0,
+        jitterBufferDelay: inbound.jitterBufferDelay || 0,
+        jitterBufferEmittedCount: inbound.jitterBufferEmittedCount || 0
+      };
+    } catch (error) {
+      console.warn(`WebRTC browser stats unavailable: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }, WEBRTC_STATS_INTERVAL_MS);
+}
+
+function startWebRtcRenderStats(video, stream) {
+  if (!video || typeof video.requestVideoFrameCallback !== "function") return;
+  if (webrtc.renderStats?.stream === stream) return;
+
+  if (webrtc.renderStats?.callbackId && typeof video.cancelVideoFrameCallback === "function") {
+    video.cancelVideoFrameCallback(webrtc.renderStats.callbackId);
+  }
+
+  webrtc.renderStats = {
+    stream,
+    lastLoggedAtMs: performance.now(),
+    lastPresentedFrames: 0,
+    callbackId: null
+  };
+
+  const onVideoFrame = (now, metadata) => {
+    if (video.srcObject !== stream) return;
+
+    const previous = webrtc.renderStats;
+    if (!previous || previous.stream !== stream) return;
+    const elapsedSec = Math.max(0.001, (now - previous.lastLoggedAtMs) / 1000);
+    const presentedFrames = Number(metadata.presentedFrames) || 0;
+    const renderedFrameDelta = Math.max(0, presentedFrames - previous.lastPresentedFrames);
+
+    if (now - previous.lastLoggedAtMs >= WEBRTC_STATS_INTERVAL_MS) {
+      const renderFps = renderedFrameDelta / elapsedSec;
+      const receiveToRenderMs =
+        Number.isFinite(metadata.receiveTime) && Number.isFinite(metadata.expectedDisplayTime)
+          ? metadata.expectedDisplayTime - metadata.receiveTime
+          : null;
+      const captureToRenderMs =
+        Number.isFinite(metadata.captureTime) && Number.isFinite(metadata.expectedDisplayTime)
+          ? metadata.expectedDisplayTime - metadata.captureTime
+          : null;
+      const renderQueueMs = Number.isFinite(metadata.expectedDisplayTime) ? metadata.expectedDisplayTime - now : null;
+      const processingMs = Number.isFinite(metadata.processingDuration) ? metadata.processingDuration * 1000 : null;
+
+      console.info(
+        [
+          "WebRTC browser render stats",
+          `renderFps=${formatNullableNumber(renderFps)}`,
+          `receiveToRenderMs=${formatNullableNumber(receiveToRenderMs)}`,
+          `captureToRenderMs=${formatNullableNumber(captureToRenderMs)}`,
+          `renderQueueMs=${formatNullableNumber(renderQueueMs)}`,
+          `processingMs=${formatNullableNumber(processingMs)}`,
+          `videoSize=${metadata.width || video.videoWidth || "-"}x${metadata.height || video.videoHeight || "-"}`
+        ].join(" ")
+      );
+
+      previous.lastLoggedAtMs = now;
+      previous.lastPresentedFrames = presentedFrames;
+    }
+
+    previous.callbackId = video.requestVideoFrameCallback(onVideoFrame);
+  };
+
+  webrtc.renderStats.callbackId = video.requestVideoFrameCallback(onVideoFrame);
+}
+
 function attachWebRtcStream(stream) {
   webrtc.remoteStream = stream;
   state.primaryCameraName = "front";
@@ -1512,6 +1658,8 @@ function attachWebRtcStream(stream) {
       });
     }
   }
+
+  startWebRtcRenderStats(elements.video, stream);
 
   const frontFeed = getCameraState("front");
   if (frontFeed) {
@@ -1566,6 +1714,7 @@ function clearWebRtcStream() {
 
 function closeWebRtcPeerConnection(clearStream = true) {
   webrtc.offerRequested = false;
+  stopWebRtcStats();
   const pc = webrtc.pc;
   webrtc.pc = null;
   if (pc) {
@@ -1599,9 +1748,18 @@ function scheduleWebRtcReconnect(reason) {
 
 function createWebRtcPeerConnection() {
   const pc = new RTCPeerConnection({ iceServers: [] });
+  startWebRtcPeerStats(pc);
 
   pc.ontrack = (event) => {
     console.info(`WebRTC remote track kind=${event.track.kind} id=${event.track.id}`);
+    if (event.receiver && "playoutDelayHint" in event.receiver) {
+      try {
+        event.receiver.playoutDelayHint = 0;
+        console.info("WebRTC receiver playoutDelayHint=0");
+      } catch {
+        console.info("WebRTC receiver playoutDelayHint unavailable");
+      }
+    }
     const [stream] = event.streams;
     attachWebRtcStream(stream || new MediaStream([event.track]));
     event.track.onended = () => {


### PR DESCRIPTION
## Summary
- Change the WebRTC publisher defaults to a low-latency 640x480 at 20 fps profile.
- Drain rpicam/libcamera MJPEG output continuously and keep only the newest frame, with dropped-frame/capture timing logs.
- Use unbuffered aiortc MediaRelay subscribers and prefer H.264 in codec negotiation.
- Add Pi outbound stats and browser receive/render stats so latency can be attributed to capture, encode/input handoff, network send/receive, jitter buffer, decode, and render.
- Document the tuning order for delay, sharpness, and stability.

## Validation
- python3 -m py_compile pi/webrtc_camera.py pi/webrtc_publisher.py pi/gateway.py
- node --check web/app.js
- npm --prefix backend run check
- git diff --cached --check

## Notes
- Live Pi camera media was not retested from this Mac; the changes are syntax-checked and targeted to the existing working WebRTC path.