### PR TITLE
[codex] Add second WebRTC camera feed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,10 @@ BACKEND_PORT ?= 3000
 HOST_IP ?= $(or $(PC_IP),$(MAC_IP))
 PI_DEVICE_ID ?= pi-01
 PI_LIDAR_ENABLED ?= 1
-PI_LIDAR_PORT ?= /dev/ttyUSB0
+PI_LIDAR_PORT ?=
 PI_VENV_DIR ?= .venv
+PI_GATEWAY_ENV = BACKEND_WS_BASE=ws://$(HOST_IP):$(BACKEND_PORT) PI_DEVICE_ID=$(PI_DEVICE_ID) LIDAR_ENABLED=$(PI_LIDAR_ENABLED)$(if $(strip $(PI_LIDAR_PORT)), LIDAR_SERIAL_PORT=$(PI_LIDAR_PORT),)
+PI_WEBRTC_ENV = BACKEND_WS_BASE=ws://$(HOST_IP):$(BACKEND_PORT) PI_DEVICE_ID=$(PI_DEVICE_ID)
 
 .PHONY: help serve check run backend-install backend-ensure backend-dev backend-start pc-setup pc-backend pc-web pc-start mac-setup mac-backend mac-web mac-start pi-install pi-setup pi-run pi-run-echo pi-run-esc pi-run-webrtc pi-connect-echo pi-connect-esc pi-connect-webrtc-echo pi-connect-webrtc-esc pi-backend-check pi-keys
 
@@ -35,8 +37,8 @@ help:
 	@echo "  make pi-run-webrtc   - Run the Pi WebRTC camera publisher"
 	@echo "  make pi-connect-echo PC_IP=<ip> - Connect Pi echo mode to the PC backend with LiDAR streaming"
 	@echo "  make pi-connect-esc  PC_IP=<ip> - Connect Pi ESC mode to the PC backend with LiDAR streaming"
-	@echo "  make pi-connect-webrtc-echo PC_IP=<ip> - Connect Pi controls in echo mode and publish one WebRTC camera"
-	@echo "  make pi-connect-webrtc-esc  PC_IP=<ip> - Connect Pi controls in ESC mode and publish one WebRTC camera"
+	@echo "  make pi-connect-webrtc-echo PC_IP=<ip> - Connect Pi controls in echo mode and publish two WebRTC cameras"
+	@echo "  make pi-connect-webrtc-esc  PC_IP=<ip> - Connect Pi controls in ESC mode and publish two WebRTC cameras"
 	@echo "  make pi-backend-check PC_IP=<ip> - Check backend health from the Pi"
 	@echo "  make pi-keys         - Run keyboard-to-ESP serial bridge"
 	@echo "  make help   - Show this help message"
@@ -117,7 +119,7 @@ pi-connect-echo:
 		exit 1; \
 	fi
 	@. "$(PI_VENV_DIR)/bin/activate"; \
-	BACKEND_WS_BASE=ws://$(HOST_IP):$(BACKEND_PORT) PI_DEVICE_ID=$(PI_DEVICE_ID) LIDAR_ENABLED=$(PI_LIDAR_ENABLED) LIDAR_SERIAL_PORT=$(PI_LIDAR_PORT) PI_MOTOR_DRIVER=echo python3 pi/gateway.py
+	$(PI_GATEWAY_ENV) PI_MOTOR_DRIVER=echo python3 pi/gateway.py
 
 pi-connect-esc:
 	@if [ -z "$(HOST_IP)" ]; then \
@@ -129,7 +131,7 @@ pi-connect-esc:
 		exit 1; \
 	fi
 	@. "$(PI_VENV_DIR)/bin/activate"; \
-	BACKEND_WS_BASE=ws://$(HOST_IP):$(BACKEND_PORT) PI_DEVICE_ID=$(PI_DEVICE_ID) LIDAR_ENABLED=$(PI_LIDAR_ENABLED) LIDAR_SERIAL_PORT=$(PI_LIDAR_PORT) PI_MOTOR_DRIVER=esc python3 pi/gateway.py
+	$(PI_GATEWAY_ENV) PI_MOTOR_DRIVER=esc python3 pi/gateway.py
 
 pi-connect-webrtc-echo:
 	@if [ -z "$(HOST_IP)" ]; then \
@@ -142,8 +144,8 @@ pi-connect-webrtc-echo:
 	fi
 	@. "$(PI_VENV_DIR)/bin/activate"; \
 	trap 'kill 0 >/dev/null 2>&1' INT TERM EXIT; \
-	BACKEND_WS_BASE=ws://$(HOST_IP):$(BACKEND_PORT) PI_DEVICE_ID=$(PI_DEVICE_ID) LIDAR_ENABLED=$(PI_LIDAR_ENABLED) LIDAR_SERIAL_PORT=$(PI_LIDAR_PORT) PI_MOTOR_DRIVER=echo PI_CAMERA_JPEG_ENABLED=0 python3 pi/gateway.py & \
-	BACKEND_WS_BASE=ws://$(HOST_IP):$(BACKEND_PORT) PI_DEVICE_ID=$(PI_DEVICE_ID) python3 pi/webrtc_publisher.py & \
+	$(PI_GATEWAY_ENV) PI_MOTOR_DRIVER=echo PI_CAMERA_JPEG_ENABLED=0 python3 pi/gateway.py & \
+	$(PI_WEBRTC_ENV) python3 pi/webrtc_publisher.py & \
 	wait
 
 pi-connect-webrtc-esc:
@@ -157,8 +159,8 @@ pi-connect-webrtc-esc:
 	fi
 	@. "$(PI_VENV_DIR)/bin/activate"; \
 	trap 'kill 0 >/dev/null 2>&1' INT TERM EXIT; \
-	BACKEND_WS_BASE=ws://$(HOST_IP):$(BACKEND_PORT) PI_DEVICE_ID=$(PI_DEVICE_ID) LIDAR_ENABLED=$(PI_LIDAR_ENABLED) LIDAR_SERIAL_PORT=$(PI_LIDAR_PORT) PI_MOTOR_DRIVER=esc PI_CAMERA_JPEG_ENABLED=0 python3 pi/gateway.py & \
-	BACKEND_WS_BASE=ws://$(HOST_IP):$(BACKEND_PORT) PI_DEVICE_ID=$(PI_DEVICE_ID) python3 pi/webrtc_publisher.py & \
+	$(PI_GATEWAY_ENV) PI_MOTOR_DRIVER=esc PI_CAMERA_JPEG_ENABLED=0 python3 pi/gateway.py & \
+	$(PI_WEBRTC_ENV) python3 pi/webrtc_publisher.py & \
 	wait
 
 pi-backend-check:

--- a/README.md
+++ b/README.md
@@ -152,19 +152,18 @@ If you are on campus or guest Wi-Fi, use the PC's Tailscale IP instead of its
 local Wi-Fi IP.
 
 `make pi-connect-echo` now carries LiDAR scans over the same backend path by
-default. Override the serial device with `PI_LIDAR_PORT=/dev/ttyUSB1` or disable
-streaming with `PI_LIDAR_ENABLED=0`.
+default. The Makefile leaves the serial device unset unless you pass
+`PI_LIDAR_PORT=/dev/ttyUSB1`, so `gateway.py` can apply its motor-driver-specific
+default. Disable streaming with `PI_LIDAR_ENABLED=0`.
 
 ### 4. Use the web app
 
 Open `http://127.0.0.1:8080` on the PC and press the arrow keys.
 
-If two camera modules are attached to the Pi, the main view and side preview now
-render those live Pi feeds over the backend WebSocket path instead of using the
-browser's local webcam. By default, the gateway streams camera index `0` as the
-front feed and camera index `1` as the back feed. The frontend settings menu
-also exposes a camera FPS slider so you can raise or lower the live stream rate
-without restarting the Pi gateway.
+If two camera modules are attached to the Pi, the main view and side preview use
+camera index `0` as the front feed and camera index `1` as the back feed. The
+WebRTC targets publish both feeds over WebRTC; the older non-WebRTC Pi targets
+still carry camera frames over the backend WebSocket path.
 
 Expected Pi output:
 
@@ -302,7 +301,11 @@ python3 pi/gateway.py
 - `make pi-run-esc`: run the Pi gateway with direct ESC control from Pi GPIO
 - `make pi-connect-echo PC_IP=<ip>`: connect the Pi echo gateway to the PC backend
 - `make pi-connect-esc PC_IP=<ip>`: connect the Pi ESC gateway to the PC backend
+- `make pi-connect-webrtc-echo PC_IP=<ip>`: connect echo controls and publish front/back WebRTC video
+- `make pi-connect-webrtc-esc PC_IP=<ip>`: connect ESC controls and publish front/back WebRTC video
 - `CAMERA_STREAM_HZ`, `CAMERA_FRAME_WIDTH`, `CAMERA_FRAME_HEIGHT`, `CAMERA_JPEG_QUALITY`: tune Pi camera streaming
+- `WEBRTC_CAMERA_FRONT_INDEX`, `WEBRTC_CAMERA_BACK_INDEX`, `WEBRTC_CAMERA_WIDTH`, `WEBRTC_CAMERA_HEIGHT`, `WEBRTC_CAMERA_FPS`: tune WebRTC camera streaming
+- `PI_LIDAR_PORT=/dev/ttyUSB1`: override the LiDAR serial port when the gateway default is wrong
 - `PI_MOTOR_DRIVER=esc`, `ESC_LEFT_GPIO`, `ESC_RIGHT_GPIO`, `ESC_MAX_SPEED`, `ESC_WATCHDOG_TIMEOUT_MS`: tune Pi ESC control
 - `make pi-keys`: send direct arrow-key serial input to an attached ESP32
 - `make help`: list available targets

--- a/docs/webrtc-video-first-pass.md
+++ b/docs/webrtc-video-first-pass.md
@@ -11,7 +11,7 @@ Browser
   web/app.js
   - /ws?role=ui                         existing controls, telemetry, LiDAR
   - /webrtc?role=viewer&deviceId=pi-01  WebRTC signaling only
-  - RTCPeerConnection                   receives one live video track
+  - RTCPeerConnection                   receives front and back live video tracks
 
 PC backend
   backend/src/server.js
@@ -27,7 +27,7 @@ Raspberry Pi
   pi/webrtc_publisher.py
   - connects to /webrtc as role=pi
   - creates one RTCPeerConnection per browser viewer
-  - publishes one latest-frame-only camera track from pi/webrtc_camera.py
+  - publishes front and back latest-frame-only camera tracks from pi/webrtc_camera.py
 ```
 
 The first negotiation flow is:
@@ -35,7 +35,7 @@ The first negotiation flow is:
 1. Browser opens `/webrtc?role=viewer&deviceId=pi-01`.
 2. Pi publisher opens `/webrtc?role=pi&deviceId=pi-01`.
 3. Browser sends `viewer:ready`.
-4. Pi creates an offer with one video track and sends `webrtc:offer`.
+4. Pi creates an offer with two video tracks and sends `webrtc:offer`.
 5. Browser creates an answer and sends `webrtc:answer`.
 6. Browser and Pi log SDP, ICE candidates, ICE state, signaling state, peer
    connection state, capture timing, outbound stats, and browser receive/render
@@ -124,10 +124,14 @@ make pi-connect-webrtc-esc PC_IP=<pc-ip-or-tailscale-ip>
 Those targets start two Pi processes:
 
 - `pi/gateway.py` for the existing controls and telemetry path
-- `pi/webrtc_publisher.py` for the new one-camera WebRTC video path
+- `pi/webrtc_publisher.py` for the two-camera WebRTC video path
 
 They also set `PI_CAMERA_JPEG_ENABLED=0` so the old JPEG frame sender does not
 open the camera at the same time as the WebRTC publisher.
+
+LiDAR still runs through `pi/gateway.py`. The Makefile no longer forces a LiDAR
+serial port by default; pass `PI_LIDAR_PORT=/dev/ttyUSB1` only when the gateway
+startup log shows it is probing the wrong device.
 
 ### 4. Open the browser
 
@@ -146,7 +150,8 @@ http://<pc-ip>:8080?backendHost=<pc-ip>&deviceId=pi-01
 ### 5. Useful WebRTC knobs
 
 ```bash
-WEBRTC_CAMERA_INDEX=0
+WEBRTC_CAMERA_FRONT_INDEX=0
+WEBRTC_CAMERA_BACK_INDEX=1
 WEBRTC_CAMERA_BACKEND=auto     # auto | rpicam | opencv
 WEBRTC_CAMERA_WIDTH=640
 WEBRTC_CAMERA_HEIGHT=480
@@ -188,7 +193,7 @@ Pi publisher logs include:
 - camera capture FPS, dropped old frames, JPEG decode time, and
   capture-to-encode-input handoff time
 - outbound WebRTC frame rate, network send bitrate, packet rate, and encode time
-  per frame when aiortc exposes it
+  per frame when aiortc exposes it, tagged by camera
 
 Browser logs include:
 
@@ -198,7 +203,7 @@ Browser logs include:
 - local and remote ICE candidates
 - peer connection, ICE connection, ICE gathering, and signaling state
 - receive frame rate, network receive bitrate, decode time, jitter-buffer delay,
-  dropped frames, and packet loss
+  dropped frames, and packet loss, tagged by camera when browser stats expose it
 - render frame rate, receive-to-render delay, capture-to-render delay when the
   browser exposes it, render queue delay, and processing time
 
@@ -243,7 +248,7 @@ More stability:
 
 ## Current Limits
 
-- One camera only: front camera index `0` by default.
+- Two cameras: front camera index `0` and back camera index `1` by default.
 - Robot controls still use the existing backend `/ws` path.
 - The backend does not forward video media. It only forwards signaling.
 - Backend-managed camera recording still depends on the old JPEG frame path and
@@ -254,10 +259,8 @@ More stability:
 
 1. Add `RTCDataChannel` for control and telemetry after the video path is stable.
    Keep `/ws` controls as fallback during the migration.
-2. Add a second camera by creating a second camera track in `pi/webrtc_publisher.py`
-   and a second `<video>` attachment in `web/app.js`.
-3. Add TURN/STUN configuration to both the browser `RTCPeerConnection` and the
+2. Add TURN/STUN configuration to both the browser `RTCPeerConnection` and the
    Pi publisher `RTCPeerConnection`.
-4. Add camera switching by signaling the desired camera over the existing control
+3. Add camera switching by signaling the desired camera over the existing control
    path first, then later over the data channel.
-5. Move recording to WebRTC-compatible capture after the live path is reliable.
+4. Move recording to WebRTC-compatible capture after the live path is reliable.

--- a/pi/README.md
+++ b/pi/README.md
@@ -13,7 +13,7 @@ Responsibilities:
 - Stream live JPEG frames for both configured Pi cameras to the frontend.
 - Stream live LiDAR scans (`lidar.scan`) to backend for web rendering.
 
-The first WebRTC video path runs as a separate Pi publisher process:
+The WebRTC video path runs as a separate Pi publisher process:
 `pi/webrtc_publisher.py`. Use `PI_CAMERA_JPEG_ENABLED=0` on `gateway.py` when
 the WebRTC publisher owns the camera. See
 [WebRTC Video First Pass](../docs/webrtc-video-first-pass.md).
@@ -214,7 +214,8 @@ The ESP firmware interprets ANSI arrow escape sequences, so this script sends
 - `CAMERA_FRAME_HEIGHT` default: `720`
 - `CAMERA_JPEG_QUALITY` default: `60`
 - `PI_CAMERA_JPEG_ENABLED` default: `1` (set `0` when `pi/webrtc_publisher.py` owns the camera)
-- `WEBRTC_CAMERA_INDEX` default: `CAMERA_FRONT_INDEX` / `0`
+- `WEBRTC_CAMERA_FRONT_INDEX` default: `WEBRTC_CAMERA_INDEX` / `CAMERA_FRONT_INDEX` / `0`
+- `WEBRTC_CAMERA_BACK_INDEX` default: `CAMERA_BACK_INDEX` / `1`
 - `WEBRTC_CAMERA_BACKEND` default: `auto`, supported values: `auto`, `rpicam`, `opencv`
 - `WEBRTC_CAMERA_WIDTH` / `WEBRTC_CAMERA_HEIGHT` default to `640` / `480`
 - `WEBRTC_CAMERA_FPS` default: `20`

--- a/pi/gateway.py
+++ b/pi/gateway.py
@@ -1979,11 +1979,12 @@ async def async_main() -> None:
     )
     config = Config.from_env()
     logging.info(
-        "Pi gateway starting deviceId=%s backend=%s motorDriver=%s lidarEnabled=%s cameraJpegEnabled=%s",
+        "Pi gateway starting deviceId=%s backend=%s motorDriver=%s lidarEnabled=%s lidarPort=%s cameraJpegEnabled=%s",
         config.device_id,
         config.ws_url,
         config.motor_driver,
         config.lidar_enabled,
+        config.lidar_port,
         config.camera_jpeg_enabled,
     )
     gateway = PiGateway(config)

--- a/pi/webrtc_camera.py
+++ b/pi/webrtc_camera.py
@@ -154,7 +154,7 @@ class RpicamMjpegCameraTrack(VideoStreamTrack):
         self._latest_event = asyncio.Event()
         self._has_unconsumed_frame = False
         self._timing_logger = CameraTimingLogger(
-            source=f"{command_name}:mjpeg",
+            source=f"{command_name}:mjpeg:index={config.camera_index}",
             log_interval_sec=config.stats_interval_sec,
         )
         self._started_once = False
@@ -343,7 +343,7 @@ class OpenCvCameraTrack(VideoStreamTrack):
         self._capture: Optional[object] = None
         self._last_frame_monotonic = 0.0
         self._timing_logger = CameraTimingLogger(
-            source="opencv",
+            source=f"opencv:index={config.camera_index}",
             log_interval_sec=config.stats_interval_sec,
         )
 

--- a/pi/webrtc_publisher.py
+++ b/pi/webrtc_publisher.py
@@ -3,7 +3,7 @@
 Minimal Raspberry Pi WebRTC video publisher.
 
 This process connects to the backend /webrtc WebSocket as role=pi, creates one
-RTCPeerConnection per browser viewer, and publishes one camera track.
+RTCPeerConnection per browser viewer, and publishes front and back camera tracks.
 """
 
 from __future__ import annotations
@@ -13,7 +13,7 @@ import json
 import logging
 import os
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlencode
 
 import websockets
@@ -26,6 +26,7 @@ from webrtc_camera import CameraTrackConfig, create_camera_track
 
 
 JsonDict = Dict[str, Any]
+CAMERA_NAMES: Tuple[str, str] = ("front", "back")
 
 
 def env_flag(name: str, default: bool = False) -> bool:
@@ -67,7 +68,8 @@ class Config:
     reconnect_max_sec: float
     log_sdp: bool
     camera_backend: str
-    camera_index: int
+    camera_front_index: int
+    camera_back_index: int
     camera_width: int
     camera_height: int
     camera_fps: float
@@ -93,7 +95,14 @@ class Config:
             reconnect_max_sec=env_float("PI_RECONNECT_MAX_SEC", 20.0),
             log_sdp=env_flag("WEBRTC_LOG_SDP", default=True),
             camera_backend=os.getenv("WEBRTC_CAMERA_BACKEND", "auto"),
-            camera_index=env_int_any(("WEBRTC_CAMERA_INDEX", "CAMERA_FRONT_INDEX", "CAMERA_LEFT_INDEX"), 0),
+            camera_front_index=env_int_any(
+                ("WEBRTC_CAMERA_FRONT_INDEX", "WEBRTC_CAMERA_INDEX", "CAMERA_FRONT_INDEX", "CAMERA_LEFT_INDEX"),
+                0,
+            ),
+            camera_back_index=env_int_any(
+                ("WEBRTC_CAMERA_BACK_INDEX", "WEBRTC_CAMERA_RIGHT_INDEX", "CAMERA_BACK_INDEX", "CAMERA_RIGHT_INDEX"),
+                1,
+            ),
             camera_width=env_int("WEBRTC_CAMERA_WIDTH", 640),
             camera_height=env_int("WEBRTC_CAMERA_HEIGHT", 480),
             camera_fps=env_float("WEBRTC_CAMERA_FPS", 20.0),
@@ -102,10 +111,17 @@ class Config:
             stats_interval_sec=env_float("WEBRTC_STATS_INTERVAL_SEC", 2.0),
         )
 
-    def camera_track_config(self) -> CameraTrackConfig:
+    def camera_track_config(self, camera_name: str) -> CameraTrackConfig:
+        if camera_name == "front":
+            camera_index = self.camera_front_index
+        elif camera_name == "back":
+            camera_index = self.camera_back_index
+        else:
+            raise ValueError(f"unknown camera name: {camera_name}")
+
         return CameraTrackConfig(
             backend=self.camera_backend,
-            camera_index=self.camera_index,
+            camera_index=camera_index,
             width=self.camera_width,
             height=self.camera_height,
             fps=self.camera_fps,
@@ -194,10 +210,13 @@ def describe_codec(codec: Any) -> str:
 class WebRtcPublisher:
     def __init__(self, config: Config) -> None:
         self.config = config
-        self.relay = MediaRelay()
-        self.source_track = create_camera_track(config.camera_track_config())
+        self.relays = {camera_name: MediaRelay() for camera_name in CAMERA_NAMES}
+        self.source_tracks = {
+            camera_name: create_camera_track(config.camera_track_config(camera_name)) for camera_name in CAMERA_NAMES
+        }
         self.peers: Dict[str, RTCPeerConnection] = {}
         self.stats_tasks: Dict[str, asyncio.Task[None]] = {}
+        self.peer_senders: Dict[str, List[Tuple[str, RTCRtpSender]]] = {}
         self.ws: Optional[Any] = None
 
     async def run_forever(self) -> None:
@@ -264,15 +283,29 @@ class WebRtcPublisher:
         except asyncio.TimeoutError:
             logging.warning("ICE gathering timed out viewerId=%s state=%s", viewer_id, pc.iceGatheringState)
 
-    def _prefer_video_codec(self, pc: RTCPeerConnection, sender: RTCRtpSender, viewer_id: str) -> None:
+    @staticmethod
+    def _sender_transceiver(pc: RTCPeerConnection, sender: RTCRtpSender) -> Optional[Any]:
+        return next((item for item in pc.getTransceivers() if item.sender == sender), None)
+
+    def _prefer_video_codec(
+        self,
+        pc: RTCPeerConnection,
+        sender: RTCRtpSender,
+        viewer_id: str,
+        camera_name: str,
+    ) -> None:
         requested_codec = self.config.video_codec.strip().lower().replace("h.264", "h264")
         if not requested_codec or requested_codec == "auto":
-            logging.info("Video codec preference viewerId=%s requested=auto", viewer_id)
+            logging.info("Video codec preference viewerId=%s camera=%s requested=auto", viewer_id, camera_name)
             return
 
-        transceiver = next((item for item in pc.getTransceivers() if item.sender == sender), None)
+        transceiver = self._sender_transceiver(pc, sender)
         if transceiver is None:
-            logging.warning("Video codec preference skipped viewerId=%s reason=missing_transceiver", viewer_id)
+            logging.warning(
+                "Video codec preference skipped viewerId=%s camera=%s reason=missing_transceiver",
+                viewer_id,
+                camera_name,
+            )
             return
 
         capabilities = RTCRtpSender.getCapabilities("video")
@@ -286,8 +319,9 @@ class WebRtcPublisher:
 
         if not preferred_codecs:
             logging.warning(
-                "Video codec preference unavailable viewerId=%s requested=%s available=%s",
+                "Video codec preference unavailable viewerId=%s camera=%s requested=%s available=%s",
                 viewer_id,
+                camera_name,
                 self.config.video_codec,
                 ", ".join(describe_codec(codec) for codec in capabilities.codecs),
             )
@@ -295,14 +329,15 @@ class WebRtcPublisher:
 
         transceiver.setCodecPreferences([*preferred_codecs, *fallback_codecs])
         logging.info(
-            "Video codec preference viewerId=%s requested=%s preferred=%s note=%s",
+            "Video codec preference viewerId=%s camera=%s requested=%s preferred=%s note=%s",
             viewer_id,
+            camera_name,
             self.config.video_codec,
             ", ".join(describe_codec(codec) for codec in preferred_codecs),
             "H264 can use hardware only if the local aiortc/PyAV encoder stack exposes it",
         )
 
-    async def _stats_loop(self, viewer_id: str, sender: RTCRtpSender) -> None:
+    async def _stats_loop(self, viewer_id: str, camera_name: str, sender: RTCRtpSender) -> None:
         last_logged_at = asyncio.get_running_loop().time()
         last_frames_encoded: Optional[int] = None
         last_total_encode_time: Optional[float] = None
@@ -318,7 +353,12 @@ class WebRtcPublisher:
             try:
                 report = await sender.getStats()
             except Exception as exc:
-                logging.warning("WebRTC outbound stats unavailable viewerId=%s error=%s", viewer_id, exc)
+                logging.warning(
+                    "WebRTC outbound stats unavailable viewerId=%s camera=%s error=%s",
+                    viewer_id,
+                    camera_name,
+                    exc,
+                )
                 continue
 
             outbound_stats = None
@@ -331,7 +371,11 @@ class WebRtcPublisher:
                     break
 
             if outbound_stats is None:
-                logging.info("WebRTC outbound stats viewerId=%s unavailable=no_outbound_video_stat", viewer_id)
+                logging.info(
+                    "WebRTC outbound stats viewerId=%s camera=%s unavailable=no_outbound_video_stat",
+                    viewer_id,
+                    camera_name,
+                )
                 continue
 
             frames_encoded = stat_value(outbound_stats, "framesEncoded")
@@ -361,10 +405,11 @@ class WebRtcPublisher:
 
             logging.info(
                 (
-                    "WebRTC outbound stats viewerId=%s outboundFps=%s encodeMsPerFrame=%s "
+                    "WebRTC outbound stats viewerId=%s camera=%s outboundFps=%s encodeMsPerFrame=%s "
                     "networkSendKbps=%s packetRate=%s framesEncoded=%s packetsSent=%s bytesSent=%s"
                 ),
                 viewer_id,
+                camera_name,
                 f"{outbound_fps:.1f}" if outbound_fps is not None else "unavailable",
                 f"{encode_ms_per_frame:.1f}" if encode_ms_per_frame is not None else "unavailable",
                 f"{bitrate_kbps:.0f}" if bitrate_kbps is not None else "unavailable",
@@ -387,12 +432,19 @@ class WebRtcPublisher:
         await self._close_peer(viewer_id)
         pc = RTCPeerConnection()
         self.peers[viewer_id] = pc
-        sender = pc.addTrack(self.relay.subscribe(self.source_track, buffered=False))
-        self._prefer_video_codec(pc, sender, viewer_id)
-        self.stats_tasks[viewer_id] = asyncio.create_task(
-            self._stats_loop(viewer_id, sender),
-            name=f"webrtc-outbound-stats-{viewer_id}",
-        )
+        self.peer_senders[viewer_id] = []
+
+        for camera_name in CAMERA_NAMES:
+            sender = pc.addTrack(
+                self.relays[camera_name].subscribe(self.source_tracks[camera_name], buffered=False)
+            )
+            self.peer_senders[viewer_id].append((camera_name, sender))
+            self._prefer_video_codec(pc, sender, viewer_id, camera_name)
+            stats_key = f"{viewer_id}:{camera_name}"
+            self.stats_tasks[stats_key] = asyncio.create_task(
+                self._stats_loop(viewer_id, camera_name, sender),
+                name=f"webrtc-outbound-stats-{viewer_id}-{camera_name}",
+            )
 
         @pc.on("connectionstatechange")
         async def on_connection_state_change() -> None:
@@ -410,8 +462,27 @@ class WebRtcPublisher:
         def on_signaling_state_change() -> None:
             logging.info("Signaling state viewerId=%s state=%s", viewer_id, pc.signalingState)
 
-        logging.info("Created peer connection viewerId=%s", viewer_id)
+        logging.info("Created peer connection viewerId=%s cameras=%s", viewer_id, ",".join(CAMERA_NAMES))
         return pc
+
+    def _track_metadata(self, viewer_id: str) -> List[JsonDict]:
+        pc = self.peers.get(viewer_id)
+        sender_entries = self.peer_senders.get(viewer_id, [])
+        tracks: List[JsonDict] = []
+
+        for index, (camera_name, sender) in enumerate(sender_entries):
+            transceiver = self._sender_transceiver(pc, sender) if pc is not None else None
+            mid = getattr(transceiver, "mid", None)
+            tracks.append(
+                {
+                    "cameraName": camera_name,
+                    "kind": "video",
+                    "mid": str(mid) if mid is not None else str(index),
+                    "order": index,
+                }
+            )
+
+        return tracks
 
     async def _start_offer(self, viewer_id: str) -> None:
         pc = await self._create_peer(viewer_id)
@@ -425,6 +496,7 @@ class WebRtcPublisher:
             {
                 "type": "webrtc:offer",
                 "viewerId": viewer_id,
+                "tracks": self._track_metadata(viewer_id),
                 "sdp": {
                     "type": description.type,
                     "sdp": description.sdp,
@@ -463,10 +535,13 @@ class WebRtcPublisher:
         await pc.addIceCandidate(candidate)
 
     async def _close_peer(self, viewer_id: str) -> None:
-        stats_task = self.stats_tasks.pop(viewer_id, None)
-        if stats_task is not None:
+        for stats_key in [key for key in self.stats_tasks.keys() if key.startswith(f"{viewer_id}:")]:
+            stats_task = self.stats_tasks.pop(stats_key, None)
+            if stats_task is None:
+                continue
             stats_task.cancel()
 
+        self.peer_senders.pop(viewer_id, None)
         pc = self.peers.pop(viewer_id, None)
         if pc is None:
             return
@@ -511,7 +586,8 @@ class WebRtcPublisher:
 
     async def close(self) -> None:
         await self._close_all_peers()
-        self.source_track.stop()
+        for source_track in self.source_tracks.values():
+            source_track.stop()
 
 
 async def async_main() -> None:
@@ -519,13 +595,14 @@ async def async_main() -> None:
     config = Config.from_env()
     logging.info(
         (
-            "Pi WebRTC publisher starting deviceId=%s signaling=%s cameraBackend=%s cameraIndex=%s "
+            "Pi WebRTC publisher starting deviceId=%s signaling=%s cameraBackend=%s cameraIndexes=front:%s,back:%s "
             "size=%sx%s fps=%.2f codec=%s statsIntervalSec=%.1f"
         ),
         config.device_id,
         config.signaling_url,
         config.camera_backend,
-        config.camera_index,
+        config.camera_front_index,
+        config.camera_back_index,
         config.camera_width,
         config.camera_height,
         config.camera_fps,

--- a/web/app.js
+++ b/web/app.js
@@ -134,7 +134,11 @@ const webrtc = {
   wsUrl: resolveWebRtcSignalingUrl(),
   viewerId: null,
   pc: null,
-  remoteStream: null,
+  remoteStreams: new Map(),
+  trackCameraNamesByMid: new Map(),
+  trackCameraNamesByOrder: [],
+  trackCameraNamesByTrackId: new Map(),
+  remoteTrackCount: 0,
   reconnectTimer: null,
   offerRequested: false,
   statsTimer: null,
@@ -489,7 +493,17 @@ function getCameraStatus(name) {
 
 function setImageSource(element, nextSrc) {
   if (!element) return;
-  if (element instanceof HTMLVideoElement) return;
+  if (element instanceof HTMLVideoElement) {
+    const nextPoster = nextSrc && nextSrc !== "webrtc" ? nextSrc : "";
+    const currentPoster = element.getAttribute("poster") || "";
+    if (currentPoster === nextPoster) return;
+    if (nextPoster) {
+      element.setAttribute("poster", nextPoster);
+    } else {
+      element.removeAttribute("poster");
+    }
+    return;
+  }
 
   const currentSrc = element.getAttribute("src") || "";
   if (currentSrc === nextSrc) return;
@@ -502,12 +516,50 @@ function setImageSource(element, nextSrc) {
   element.removeAttribute("src");
 }
 
+function setVideoStream(video, stream) {
+  if (!(video instanceof HTMLVideoElement)) return;
+  if (video.srcObject !== stream) {
+    video.srcObject = stream;
+  }
+  if (!stream) return;
+
+  const playResult = video.play();
+  if (playResult && typeof playResult.catch === "function") {
+    playResult.catch(() => {
+      // Autoplay can be blocked until the user interacts with the page.
+    });
+  }
+}
+
+function getWebRtcCameraStream(cameraName) {
+  const normalizedName = normalizeCameraName(cameraName);
+  return isKnownCameraName(normalizedName) ? webrtc.remoteStreams.get(normalizedName) || null : null;
+}
+
 function cameraHasRenderableFeed(name) {
   const feed = getCameraState(name);
   if (!feed) return false;
 
+  if (webrtc.enabled) return Boolean(getWebRtcCameraStream(name));
   if (feed.frameSrc) return true;
   return Boolean(getCameraStatus(name)?.streaming);
+}
+
+function syncWebRtcVideoElements() {
+  if (!webrtc.enabled) return;
+
+  const primaryCameraName = getPrimaryCameraName();
+  const secondaryCameraName = getSecondaryCameraName();
+  const primaryStream = getWebRtcCameraStream(primaryCameraName);
+  const secondaryStream = getWebRtcCameraStream(secondaryCameraName);
+
+  setVideoStream(elements.video, primaryStream);
+  setVideoStream(elements.primaryMiniVideo, primaryStream);
+  setVideoStream(elements.secondaryVideo, secondaryStream);
+
+  if (primaryStream) {
+    startWebRtcRenderStats(elements.video, primaryStream, primaryCameraName);
+  }
 }
 
 function syncPrimaryCameraSelection() {
@@ -532,6 +584,7 @@ function renderCameraFeeds() {
   setImageSource(elements.video, primaryFeed?.frameSrc || "");
   setImageSource(elements.primaryMiniVideo, primaryFeed?.frameSrc || "");
   setImageSource(elements.secondaryVideo, secondaryFeed?.frameSrc || "");
+  syncWebRtcVideoElements();
 
   if (elements.primaryCameraLabel) {
     elements.primaryCameraLabel.textContent = formatCameraName(primaryCameraName);
@@ -1003,6 +1056,17 @@ function updateLidarScan(payload) {
 function applyLidarStatus(payload) {
   if (!isObject(payload)) return;
 
+  console.info(
+    [
+      "LiDAR status",
+      `enabled=${payload.enabled ?? "unknown"}`,
+      `connected=${payload.connected ?? "unknown"}`,
+      `driverAvailable=${payload.driverAvailable ?? "unknown"}`,
+      `port=${payload.port || "unknown"}`,
+      `lastError=${payload.lastError || ""}`
+    ].join(" ")
+  );
+
   const maxDistanceMm = Number(payload.maxDistanceMm);
   if (Number.isFinite(maxDistanceMm) && maxDistanceMm > 0) {
     lidarState.maxDistanceMm = maxDistanceMm;
@@ -1457,7 +1521,9 @@ function handleBackendMessage(message) {
 }
 
 function getWebRtcVideoElements() {
-  return [elements.video, elements.primaryMiniVideo].filter((element) => element instanceof HTMLVideoElement);
+  return [elements.video, elements.primaryMiniVideo, elements.secondaryVideo].filter(
+    (element) => element instanceof HTMLVideoElement
+  );
 }
 
 function summarizeWebRtcCandidate(candidate) {
@@ -1501,6 +1567,66 @@ function requestWebRtcOffer() {
   webrtc.offerRequested = sendWebRtcSignal({ type: "viewer:ready" });
 }
 
+function resetWebRtcTrackMetadata() {
+  webrtc.trackCameraNamesByMid.clear();
+  webrtc.trackCameraNamesByOrder = [];
+  webrtc.trackCameraNamesByTrackId.clear();
+  webrtc.remoteTrackCount = 0;
+}
+
+function configureWebRtcTrackMetadata(tracks) {
+  resetWebRtcTrackMetadata();
+  if (!Array.isArray(tracks)) return;
+
+  tracks.forEach((track, index) => {
+    if (!isObject(track)) return;
+    const cameraName = normalizeCameraName(track.cameraName);
+    if (!isKnownCameraName(cameraName)) return;
+
+    webrtc.trackCameraNamesByOrder[index] = cameraName;
+    if (track.mid !== undefined && track.mid !== null) {
+      webrtc.trackCameraNamesByMid.set(String(track.mid), cameraName);
+    }
+  });
+
+  console.info(
+    `WebRTC remote track map ${
+      webrtc.trackCameraNamesByOrder.map((cameraName, index) => `${index}:${cameraName}`).join(",") || "empty"
+    }`
+  );
+}
+
+function getWebRtcCameraNameForTrackEvent(event) {
+  const trackIndex = webrtc.remoteTrackCount;
+  webrtc.remoteTrackCount += 1;
+
+  const mid = event.transceiver?.mid;
+  if (mid !== undefined && mid !== null) {
+    const cameraName = webrtc.trackCameraNamesByMid.get(String(mid));
+    if (isKnownCameraName(cameraName)) return cameraName;
+  }
+
+  const orderedCameraName = webrtc.trackCameraNamesByOrder[trackIndex];
+  if (isKnownCameraName(orderedCameraName)) return orderedCameraName;
+
+  return CAMERA_NAMES.find((cameraName) => !webrtc.remoteStreams.has(cameraName)) || "front";
+}
+
+function getWebRtcStatsCameraName(stat) {
+  if (stat?.mid !== undefined && stat.mid !== null) {
+    const cameraName = webrtc.trackCameraNamesByMid.get(String(stat.mid));
+    if (isKnownCameraName(cameraName)) return cameraName;
+  }
+
+  const trackIdentifier = stat?.trackIdentifier || stat?.trackId;
+  if (trackIdentifier) {
+    const cameraName = webrtc.trackCameraNamesByTrackId.get(String(trackIdentifier));
+    if (isKnownCameraName(cameraName)) return cameraName;
+  }
+
+  return "unknown";
+}
+
 function formatNullableNumber(value, digits = 1) {
   return Number.isFinite(value) ? value.toFixed(digits) : "unavailable";
 }
@@ -1526,65 +1652,74 @@ function startWebRtcPeerStats(pc) {
     window.clearInterval(webrtc.statsTimer);
   }
 
-  webrtc.inboundStats = null;
+  webrtc.inboundStats = new Map();
   webrtc.statsTimer = window.setInterval(async () => {
     if (webrtc.pc !== pc) return;
 
     try {
       const report = await pc.getStats();
-      let inbound = null;
+      const inboundStats = [];
       report.forEach((stat) => {
         if (stat.type === "inbound-rtp" && (!stat.kind || stat.kind === "video")) {
-          inbound = stat;
+          inboundStats.push(stat);
         }
       });
-      if (!inbound) return;
+      if (!inboundStats.length) return;
 
       const now = performance.now();
-      const previous = webrtc.inboundStats;
-      const elapsedSec = previous ? Math.max(0.001, (now - previous.loggedAtMs) / 1000) : 0;
+      const nextStats = new Map();
 
-      const framesDecodedDelta = previous ? (inbound.framesDecoded || 0) - (previous.framesDecoded || 0) : 0;
-      const bytesReceivedDelta = previous ? (inbound.bytesReceived || 0) - (previous.bytesReceived || 0) : 0;
-      const totalDecodeTimeDelta = previous ? (inbound.totalDecodeTime || 0) - (previous.totalDecodeTime || 0) : 0;
-      const jitterBufferDelayDelta = previous ? (inbound.jitterBufferDelay || 0) - (previous.jitterBufferDelay || 0) : 0;
-      const jitterBufferFramesDelta = previous
-        ? (inbound.jitterBufferEmittedCount || 0) - (previous.jitterBufferEmittedCount || 0)
-        : 0;
+      inboundStats.forEach((inbound) => {
+        const statKey = String(inbound.id || inbound.mid || inbound.ssrc || inbound.trackIdentifier || "video");
+        const previous = webrtc.inboundStats?.get(statKey) || null;
+        const elapsedSec = previous ? Math.max(0.001, (now - previous.loggedAtMs) / 1000) : 0;
 
-      const receiveFps = previous ? framesDecodedDelta / elapsedSec : null;
-      const receiveKbps = previous ? (bytesReceivedDelta * 8) / elapsedSec / 1000 : null;
-      const decodeMsPerFrame = framesDecodedDelta > 0 ? (totalDecodeTimeDelta * 1000) / framesDecodedDelta : null;
-      const jitterBufferMs =
-        jitterBufferFramesDelta > 0 ? (jitterBufferDelayDelta * 1000) / jitterBufferFramesDelta : null;
+        const framesDecodedDelta = previous ? (inbound.framesDecoded || 0) - (previous.framesDecoded || 0) : 0;
+        const bytesReceivedDelta = previous ? (inbound.bytesReceived || 0) - (previous.bytesReceived || 0) : 0;
+        const totalDecodeTimeDelta = previous ? (inbound.totalDecodeTime || 0) - (previous.totalDecodeTime || 0) : 0;
+        const jitterBufferDelayDelta = previous ? (inbound.jitterBufferDelay || 0) - (previous.jitterBufferDelay || 0) : 0;
+        const jitterBufferFramesDelta = previous
+          ? (inbound.jitterBufferEmittedCount || 0) - (previous.jitterBufferEmittedCount || 0)
+          : 0;
 
-      console.info(
-        [
-          "WebRTC browser receive stats",
-          `receiveFps=${formatNullableNumber(receiveFps)}`,
-          `networkReceiveKbps=${formatNullableNumber(receiveKbps, 0)}`,
-          `decodeMsPerFrame=${formatNullableNumber(decodeMsPerFrame)}`,
-          `jitterBufferMs=${formatNullableNumber(jitterBufferMs)}`,
-          `framesDropped=${inbound.framesDropped ?? "unavailable"}`,
-          `packetsLost=${inbound.packetsLost ?? "unavailable"}`
-        ].join(" ")
-      );
+        const receiveFps = previous ? framesDecodedDelta / elapsedSec : null;
+        const receiveKbps = previous ? (bytesReceivedDelta * 8) / elapsedSec / 1000 : null;
+        const decodeMsPerFrame = framesDecodedDelta > 0 ? (totalDecodeTimeDelta * 1000) / framesDecodedDelta : null;
+        const jitterBufferMs =
+          jitterBufferFramesDelta > 0 ? (jitterBufferDelayDelta * 1000) / jitterBufferFramesDelta : null;
+        const cameraName = getWebRtcStatsCameraName(inbound);
 
-      webrtc.inboundStats = {
-        loggedAtMs: now,
-        framesDecoded: inbound.framesDecoded || 0,
-        bytesReceived: inbound.bytesReceived || 0,
-        totalDecodeTime: inbound.totalDecodeTime || 0,
-        jitterBufferDelay: inbound.jitterBufferDelay || 0,
-        jitterBufferEmittedCount: inbound.jitterBufferEmittedCount || 0
-      };
+        console.info(
+          [
+            "WebRTC browser receive stats",
+            `camera=${cameraName}`,
+            `receiveFps=${formatNullableNumber(receiveFps)}`,
+            `networkReceiveKbps=${formatNullableNumber(receiveKbps, 0)}`,
+            `decodeMsPerFrame=${formatNullableNumber(decodeMsPerFrame)}`,
+            `jitterBufferMs=${formatNullableNumber(jitterBufferMs)}`,
+            `framesDropped=${inbound.framesDropped ?? "unavailable"}`,
+            `packetsLost=${inbound.packetsLost ?? "unavailable"}`
+          ].join(" ")
+        );
+
+        nextStats.set(statKey, {
+          loggedAtMs: now,
+          framesDecoded: inbound.framesDecoded || 0,
+          bytesReceived: inbound.bytesReceived || 0,
+          totalDecodeTime: inbound.totalDecodeTime || 0,
+          jitterBufferDelay: inbound.jitterBufferDelay || 0,
+          jitterBufferEmittedCount: inbound.jitterBufferEmittedCount || 0
+        });
+      });
+
+      webrtc.inboundStats = nextStats;
     } catch (error) {
       console.warn(`WebRTC browser stats unavailable: ${error instanceof Error ? error.message : String(error)}`);
     }
   }, WEBRTC_STATS_INTERVAL_MS);
 }
 
-function startWebRtcRenderStats(video, stream) {
+function startWebRtcRenderStats(video, stream, cameraName = "unknown") {
   if (!video || typeof video.requestVideoFrameCallback !== "function") return;
   if (webrtc.renderStats?.stream === stream) return;
 
@@ -1594,6 +1729,7 @@ function startWebRtcRenderStats(video, stream) {
 
   webrtc.renderStats = {
     stream,
+    cameraName,
     lastLoggedAtMs: performance.now(),
     lastPresentedFrames: 0,
     callbackId: null
@@ -1624,6 +1760,7 @@ function startWebRtcRenderStats(video, stream) {
       console.info(
         [
           "WebRTC browser render stats",
+          `camera=${previous.cameraName || "unknown"}`,
           `renderFps=${formatNullableNumber(renderFps)}`,
           `receiveToRenderMs=${formatNullableNumber(receiveToRenderMs)}`,
           `captureToRenderMs=${formatNullableNumber(captureToRenderMs)}`,
@@ -1643,48 +1780,27 @@ function startWebRtcRenderStats(video, stream) {
   webrtc.renderStats.callbackId = video.requestVideoFrameCallback(onVideoFrame);
 }
 
-function attachWebRtcStream(stream) {
-  webrtc.remoteStream = stream;
-  state.primaryCameraName = "front";
+function attachWebRtcStream(cameraName, stream) {
+  const normalizedCameraName = normalizeCameraName(cameraName);
+  if (!isKnownCameraName(normalizedCameraName)) return;
 
-  for (const video of getWebRtcVideoElements()) {
-    if (video.srcObject !== stream) {
-      video.srcObject = stream;
-    }
-    const playResult = video.play();
-    if (playResult && typeof playResult.catch === "function") {
-      playResult.catch(() => {
-        // Autoplay can be blocked until the user interacts with the page.
-      });
-    }
-  }
+  webrtc.remoteStreams.set(normalizedCameraName, stream);
+  const feed = getCameraState(normalizedCameraName);
+  const track = stream.getVideoTracks()[0] || null;
+  const settings = typeof track?.getSettings === "function" ? track.getSettings() : {};
 
-  startWebRtcRenderStats(elements.video, stream);
-
-  const frontFeed = getCameraState("front");
-  if (frontFeed) {
-    frontFeed.frameSrc = "webrtc";
-    frontFeed.lastFrameAtMs = Date.now();
-    frontFeed.status = {
-      ...(frontFeed.status || {}),
-      name: "front",
+  if (feed) {
+    feed.frameSrc = "webrtc";
+    feed.lastFrameAtMs = Date.now();
+    feed.status = {
+      ...(feed.status || {}),
+      name: normalizedCameraName,
       available: true,
       streaming: true,
       backend: "webrtc",
+      width: Number(settings.width) || feed.status?.width || null,
+      height: Number(settings.height) || feed.status?.height || null,
       lastFrameAt: new Date().toISOString()
-    };
-  }
-
-  const backFeed = getCameraState("back");
-  if (backFeed) {
-    backFeed.frameSrc = "";
-    backFeed.status = {
-      ...(backFeed.status || {}),
-      name: "back",
-      available: false,
-      streaming: false,
-      backend: "disabled",
-      reason: "single-camera-webrtc"
     };
   }
 
@@ -1693,21 +1809,24 @@ function attachWebRtcStream(stream) {
 
 function clearWebRtcStream() {
   for (const video of getWebRtcVideoElements()) {
-    video.srcObject = null;
+    setVideoStream(video, null);
   }
 
-  webrtc.remoteStream = null;
-  const frontFeed = getCameraState("front");
-  if (frontFeed?.frameSrc === "webrtc") {
-    frontFeed.frameSrc = "";
-    frontFeed.status = {
-      ...(frontFeed.status || {}),
-      name: "front",
+  webrtc.remoteStreams.clear();
+  resetWebRtcTrackMetadata();
+
+  CAMERA_NAMES.forEach((cameraName) => {
+    const feed = getCameraState(cameraName);
+    if (feed?.frameSrc !== "webrtc") return;
+    feed.frameSrc = "";
+    feed.status = {
+      ...(feed.status || {}),
+      name: cameraName,
       streaming: false,
       backend: "webrtc",
       reason: "webrtc-disconnected"
     };
-  }
+  });
 
   renderCameraFeeds();
 }
@@ -1751,19 +1870,23 @@ function createWebRtcPeerConnection() {
   startWebRtcPeerStats(pc);
 
   pc.ontrack = (event) => {
-    console.info(`WebRTC remote track kind=${event.track.kind} id=${event.track.id}`);
+    if (event.track.kind !== "video") return;
+
+    const cameraName = getWebRtcCameraNameForTrackEvent(event);
+    const mid = event.transceiver?.mid ?? "-";
+    webrtc.trackCameraNamesByTrackId.set(event.track.id, cameraName);
+    console.info(`WebRTC remote track camera=${cameraName} kind=${event.track.kind} id=${event.track.id} mid=${mid}`);
     if (event.receiver && "playoutDelayHint" in event.receiver) {
       try {
         event.receiver.playoutDelayHint = 0;
-        console.info("WebRTC receiver playoutDelayHint=0");
+        console.info(`WebRTC receiver camera=${cameraName} playoutDelayHint=0`);
       } catch {
-        console.info("WebRTC receiver playoutDelayHint unavailable");
+        console.info(`WebRTC receiver camera=${cameraName} playoutDelayHint unavailable`);
       }
     }
-    const [stream] = event.streams;
-    attachWebRtcStream(stream || new MediaStream([event.track]));
+    attachWebRtcStream(cameraName, new MediaStream([event.track]));
     event.track.onended = () => {
-      scheduleWebRtcReconnect("remote track ended");
+      scheduleWebRtcReconnect(`remote ${cameraName} track ended`);
     };
   };
 
@@ -1837,6 +1960,7 @@ async function handleWebRtcOffer(message) {
   const pc = createWebRtcPeerConnection();
   webrtc.pc = pc;
   webrtc.offerRequested = false;
+  configureWebRtcTrackMetadata(message.tracks);
 
   logWebRtcSdp("Remote offer", sdp);
   await pc.setRemoteDescription(sdp);

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Camera Control Overlay</title>
-  <link rel="stylesheet" href="./styles.css?v=20260413-1" />
+  <link rel="stylesheet" href="./styles.css?v=20260413-2" />
 </head>
 <body>
   <main id="app-root" class="app">
@@ -48,7 +48,7 @@
 
           <div id="secondary-feed-shell" class="secondary-feed-shell camera-panel" aria-label="Secondary camera feed">
             <span id="secondary-camera-label" class="camera-panel-label">Back</span>
-            <img id="secondary-feed" class="secondary-feed" alt="Secondary robot camera feed" />
+            <video id="secondary-feed" class="secondary-feed" autoplay playsinline muted aria-label="Secondary robot camera feed"></video>
             <button id="switch-camera" class="switch-camera" type="button" aria-label="Swap front and back Pi camera feeds">
               <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                 <path d="M17 8a5 5 0 0 0-8.5-3.5" />
@@ -199,6 +199,6 @@
     </div>
   </main>
 
-  <script src="./app.js?v=20260413-1"></script>
+  <script src="./app.js?v=20260413-2"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- publishes front and back WebRTC camera tracks from the Pi, with track metadata for browser mapping
- renders the secondary camera as a WebRTC video element and keeps camera switching working
- improves LiDAR troubleshooting by not forcing a serial port from Makefile defaults and logging LiDAR port/status details

## Validation
- python3 -m py_compile pi/webrtc_camera.py pi/webrtc_publisher.py pi/gateway.py
- node --check web/app.js
- npm --prefix backend run check
- make -n pi-connect-webrtc-echo PC_IP=192.0.2.10 PI_VENV_DIR=/tmp/fake-venv
- make -n pi-connect-webrtc-echo PC_IP=192.0.2.10 PI_VENV_DIR=/tmp/fake-venv PI_LIDAR_PORT=/dev/ttyUSB1
- git diff --check